### PR TITLE
chore: Bump Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module tdns
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
Use latest stable upstream version