### PR TITLE
feat: send API token via Authorization Bearer header

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -3,14 +3,15 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
+	"net/url"
 	"os"
 	"time"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"golang.org/x/term"
+
+	"tdns/internal/api"
 )
 
 var adminCmd = &cobra.Command{
@@ -33,35 +34,9 @@ var listSessionsCmd = &cobra.Command{
 	Short:       "List active sessions",
 	Annotations: map[string]string{"group": "Session Management"},
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
-		url := fmt.Sprintf("%s/api/admin/sessions/list?token=%s", host, token)
-		resp, err := http.Get(url)
+		_, response, err := api.New().GetJSON("/api/admin/sessions/list", nil)
 		if err != nil {
-			fmt.Printf("Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Printf("Invalid response: %v\n", err)
-			os.Exit(1)
-		}
-
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
-			os.Exit(1)
-		}
-
-		response, ok := result["response"].(map[string]interface{})
-		if !ok {
-			fmt.Println("Unexpected response structure")
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
@@ -116,30 +91,9 @@ var deleteSessionCmd = &cobra.Command{
 			return
 		}
 
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
-		url := fmt.Sprintf("%s/api/admin/sessions/delete?token=%s&partialToken=%s", host, token, sessionID)
-
-		resp, err := http.Get(url)
-		if err != nil {
-			fmt.Printf("Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Printf("Invalid response: %v\n", err)
-			os.Exit(1)
-		}
-
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
+		q := url.Values{"partialToken": {sessionID}}
+		if _, _, err := api.New().GetJSON("/api/admin/sessions/delete", q); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
@@ -158,34 +112,13 @@ var createTokenCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
-		url := fmt.Sprintf("%s/api/admin/sessions/createToken?token=%s&user=%s&tokenName=%s", host, token, createTokenUser, createTokenName)
-
-		resp, err := http.Get(url)
+		q := url.Values{"user": {createTokenUser}, "tokenName": {createTokenName}}
+		_, response, err := api.New().GetJSON("/api/admin/sessions/createToken", q)
 		if err != nil {
-			fmt.Printf("Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Printf("Invalid response: %v\n", err)
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
-			os.Exit(1)
-		}
-
-		response, _ := result["response"].(map[string]interface{})
 		fmt.Println("✅ Token created successfully:")
 		fmt.Printf("  Username: %s\n", response["username"])
 		fmt.Printf("  Token Name: %s\n", response["tokenName"])
@@ -198,34 +131,12 @@ var adminListUsersCmd = &cobra.Command{
 	Aliases: []string{"lu"},
 	Short:   "List all system users",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
-		url := fmt.Sprintf("%s/api/admin/users/list?token=%s", host, token)
-
-		resp, err := http.Get(url)
+		_, response, err := api.New().GetJSON("/api/admin/users/list", nil)
 		if err != nil {
-			fmt.Printf("Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Printf("Invalid response: %v\n", err)
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
-			os.Exit(1)
-		}
-
-		response := result["response"].(map[string]interface{})
 		users, ok := response["users"].([]interface{})
 		if !ok || len(users) == 0 {
 			fmt.Println("No users found.")
@@ -264,33 +175,13 @@ var adminGetUserCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-		url := fmt.Sprintf("%s/api/admin/users/get?token=%s&user=%s&includeGroups=true", host, token, getUser)
-
-		resp, err := http.Get(url)
+		q := url.Values{"user": {getUser}, "includeGroups": {"true"}}
+		_, user, err := api.New().GetJSON("/api/admin/users/get", q)
 		if err != nil {
-			fmt.Printf("Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Printf("Invalid response: %v\n", err)
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
-			os.Exit(1)
-		}
-
-		user := result["response"].(map[string]interface{})
 		bold := color.New(color.Bold).SprintFunc()
 		green := color.New(color.FgGreen).SprintFunc()
 		blue := color.New(color.FgBlue).SprintFunc()
@@ -324,20 +215,9 @@ var adminCheckUpdateCmd = &cobra.Command{
 	Aliases: []string{"cu"},
 	Short:   "Check for available updates",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
-		url := fmt.Sprintf("%s/api/user/checkForUpdate?token=%s", host, token)
-		resp, err := http.Get(url)
+		result, respData, err := api.New().GetJSON("/api/user/checkForUpdate", nil)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Failed to parse response: %v\n", err)
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
@@ -347,16 +227,6 @@ var adminCheckUpdateCmd = &cobra.Command{
 			return
 		}
 
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
-			os.Exit(1)
-		}
-
-		respData := result["response"].(map[string]interface{})
 		bold := color.New(color.Bold).SprintFunc()
 		green := color.New(color.FgGreen).SprintFunc()
 		red := color.New(color.FgRed).SprintFunc()
@@ -381,10 +251,6 @@ var adminChangePasswordCmd = &cobra.Command{
 	Aliases: []string{"cp"},
 	Short:   "Change the current user's password",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
-		// Interactive mode
 		if newPassword == "" && interactive {
 			fmt.Print("Enter new password: ")
 			bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
@@ -405,33 +271,13 @@ var adminChangePasswordCmd = &cobra.Command{
 			newPassword = string(bytePassword)
 		}
 
-		// Get as parameter (unsecure)
 		if newPassword == "" {
 			fmt.Fprintln(os.Stderr, "❌ --pass is required")
 			os.Exit(1)
 		}
 
-		url := fmt.Sprintf("%s/api/user/changePassword?token=%s&pass=%s", host, token, newPassword)
-
-		resp, err := http.Get(url)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Failed to parse response: %v\n", err)
-			os.Exit(1)
-		}
-
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
+		if _, _, err := api.New().GetJSON("/api/user/changePassword", url.Values{"pass": {newPassword}}); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var convertCmd = &cobra.Command{
@@ -17,14 +17,10 @@ var convertCmd = &cobra.Command{
 	Short:   "Convert zone type",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
 		zone := args[0]
 		zoneType, _ := cmd.Flags().GetString("type")
 
 		bold := color.New(color.Bold).SprintFunc()
-		amber := color.New(color.FgYellow).SprintFunc()
 		cyan := color.New(color.FgCyan).SprintFunc()
 
 		if zoneType == "" {
@@ -32,26 +28,9 @@ var convertCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		url := fmt.Sprintf("%s/api/zones/convert?token=%s&zone=%s&type=%s", host, token, zone, zoneType)
-		resp, err := http.Get(url)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Failed to convert zone %s: %v\n", amber(zone), err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Invalid response: %v\n", err)
-			os.Exit(1)
-		}
-
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
+		q := url.Values{"zone": {zone}, "type": {zoneType}}
+		if _, _, err := api.New().GetJSON("/api/zones/convert", q); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,14 +1,15 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var validZoneTypes = map[string]bool{
@@ -27,9 +28,6 @@ var createCmd = &cobra.Command{
 	Short:   "Create one or more DNS zones",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
 		zoneType, _ := cmd.Flags().GetString("type")
 		useSerial, _ := cmd.Flags().GetBool("useSoaSerialDateScheme")
 		nameServers, _ := cmd.Flags().GetString("primaryNameServerAddresses")
@@ -43,37 +41,22 @@ var createCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		client := api.New()
 		for _, zone := range args {
-			url := fmt.Sprintf("%s/api/zones/create?token=%s&zone=%s&type=%s&useSoaSerialDateScheme=%t",
-				host, token, zone, zoneType, useSerial)
-
+			q := url.Values{
+				"zone":                   {zone},
+				"type":                   {zoneType},
+				"useSoaSerialDateScheme": {strconv.FormatBool(useSerial)},
+			}
 			if nameServers != "" {
-				url += fmt.Sprintf("&primaryNameServerAddresses=%s", nameServers)
+				q.Set("primaryNameServerAddresses", nameServers)
 			}
 
-			resp, err := http.Get(url)
+			_, response, err := client.GetJSON("/api/zones/create", q)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "❌ Failed to create zone %s: %v\n", zone, err)
-				continue
-			}
-			defer resp.Body.Close()
-
-			var result map[string]interface{}
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				fmt.Printf("Invalid response: %v\n", err)
 				os.Exit(1)
 			}
-
-			if status, ok := result["status"].(string); !ok || status != "ok" {
-				if msg, ok := result["errorMessage"].(string); ok {
-					fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-				} else {
-					fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-				}
-				os.Exit(1)
-			}
-
-			response := result["response"].(map[string]interface{})
 			fmt.Printf("✅ Zone %v created successfully.\n", response["domain"])
 		}
 	},

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var deleteCmd = &cobra.Command{
@@ -16,40 +16,12 @@ var deleteCmd = &cobra.Command{
 	Short:   "Delete DNS zone(s)",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
+		client := api.New()
 		for _, zone := range args {
-			url := fmt.Sprintf("%s/api/zones/delete?token=%s&zone=%s", host, token, zone)
-			req, err := http.NewRequest("GET", url, nil)
-			if err != nil {
-				fmt.Printf("Failed to create request: %v\n", err)
+			if _, _, err := client.GetJSON("/api/zones/delete", url.Values{"zone": {zone}}); err != nil {
+				fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 				os.Exit(1)
 			}
-
-			client := &http.Client{}
-			resp, err := client.Do(req)
-			if err != nil {
-				fmt.Printf("Delete failed for '%s': %v\n", zone, err)
-				os.Exit(1)
-			}
-			defer resp.Body.Close()
-
-			var result map[string]interface{}
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				fmt.Printf("Invalid response: %v\n", err)
-				os.Exit(1)
-			}
-
-			if status, ok := result["status"].(string); !ok || status != "ok" {
-				if msg, ok := result["errorMessage"].(string); ok {
-					fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-				} else {
-					fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-				}
-				os.Exit(1)
-			}
-
 			fmt.Printf("✅ Zone '%s' deleted successfully.\n", zone)
 		}
 	},

--- a/cmd/disable.go
+++ b/cmd/disable.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var disableZoneCmd = &cobra.Command{
@@ -17,36 +17,14 @@ var disableZoneCmd = &cobra.Command{
 	Short:   "Disable DNS zone(s)",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
 		bold := color.New(color.Bold).SprintFunc()
-		amber := color.New(color.FgYellow).SprintFunc()
 
+		client := api.New()
 		for _, zone := range args {
-			url := fmt.Sprintf("%s/api/zones/disable?token=%s&zone=%s", host, token, zone)
-			resp, err := http.Get(url)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "❌ Failed to convert zone %s: %v\n", amber(zone), err)
+			if _, _, err := client.GetJSON("/api/zones/disable", url.Values{"zone": {zone}}); err != nil {
+				fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 				os.Exit(1)
 			}
-			defer resp.Body.Close()
-
-			var result map[string]interface{}
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				fmt.Fprintf(os.Stderr, "❌ Invalid response: %v\n", err)
-				os.Exit(1)
-			}
-
-			if status, ok := result["status"].(string); !ok || status != "ok" {
-				if msg, ok := result["errorMessage"].(string); ok {
-					fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-				} else {
-					fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-				}
-				os.Exit(1)
-			}
-
 			fmt.Printf("✅ Zone %v disabled successfully.\n", bold(zone))
 		}
 	},

--- a/cmd/enable.go
+++ b/cmd/enable.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var enableZoneCmd = &cobra.Command{
@@ -17,36 +17,14 @@ var enableZoneCmd = &cobra.Command{
 	Short:   "Enable DNS zones(s)",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
 		bold := color.New(color.Bold).SprintFunc()
-		amber := color.New(color.FgYellow).SprintFunc()
 
+		client := api.New()
 		for _, zone := range args {
-			url := fmt.Sprintf("%s/api/zones/enable?token=%s&zone=%s", host, token, zone)
-			resp, err := http.Get(url)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "❌ Failed to convert zone %s: %v\n", amber(zone), err)
+			if _, _, err := client.GetJSON("/api/zones/enable", url.Values{"zone": {zone}}); err != nil {
+				fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 				os.Exit(1)
 			}
-			defer resp.Body.Close()
-
-			var result map[string]interface{}
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				fmt.Fprintf(os.Stderr, "❌ Invalid response: %v\n", err)
-				os.Exit(1)
-			}
-
-			if status, ok := result["status"].(string); !ok || status != "ok" {
-				if msg, ok := result["errorMessage"].(string); ok {
-					fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-				} else {
-					fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-				}
-				os.Exit(1)
-			}
-
 			fmt.Printf("✅ Zone %v enabled successfully.\n", bold(zone))
 		}
 	},

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var exportOutputDir string
@@ -20,19 +21,16 @@ var exportCmd = &cobra.Command{
 	Short:   "Export one or more DNS zones",
 	Args:    cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
+		client := api.New()
 		for _, zone := range args {
-			url := fmt.Sprintf("%s/api/zones/export?token=%s&zone=%s", host, token, zone)
-			resp, err := http.Get(url)
+			resp, err := client.Get("/api/zones/export", url.Values{"zone": {zone}})
 			if err != nil {
 				fmt.Printf("Export failed for %s: %v\n", zone, err)
 				continue
 			}
-			defer resp.Body.Close()
 
 			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
 			if err != nil {
 				fmt.Printf("Failed to read response for %s: %v\n", zone, err)
 				continue

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,15 +1,15 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
+	"net/url"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var importFile string
@@ -21,37 +21,28 @@ var importCmd = &cobra.Command{
 	Short:   "Import a DNS zone",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
 		zone := args[0]
 
-		data, err := ioutil.ReadFile(importFile)
+		data, err := os.ReadFile(importFile)
 		if err != nil {
 			fmt.Printf("Failed to read file: %v\n", err)
 			os.Exit(1)
 		}
 
-		url := fmt.Sprintf("%s/api/zones/import?token=%s&zone=%s&overwrite=true&overwriteSoaSerial=true", host, token, zone)
-		req, err := http.NewRequest("POST", url, strings.NewReader(string(data)))
-		if err != nil {
-			fmt.Printf("Failed to create request: %v\n", err)
-			os.Exit(1)
+		q := url.Values{
+			"zone":               {zone},
+			"overwrite":          {"true"},
+			"overwriteSoaSerial": {"true"},
 		}
-		req.Header.Set("Content-Type", "text/plain")
-
-		client := &http.Client{}
-		resp, err := client.Do(req)
+		resp, err := api.New().Post("/api/zones/import", q, bytes.NewReader(data), "text/plain")
 		if err != nil {
 			fmt.Printf("Request failed: %v\n", err)
 			os.Exit(1)
 		}
 		defer resp.Body.Close()
 
-		body, _ := ioutil.ReadAll(resp.Body)
-
 		var result map[string]interface{}
-		if err := json.Unmarshal(body, &result); err == nil {
+		if err := json.NewDecoder(resp.Body).Decode(&result); err == nil {
 			if importJSON {
 				raw, _ := json.MarshalIndent(result, "", "  ")
 				fmt.Println(string(raw))

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"sort"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var listJSON bool
@@ -19,30 +19,9 @@ var listCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List all DNS zones",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
-		url := fmt.Sprintf("%s/api/zones/list?token=%s", host, token)
-
-		resp, err := http.Get(url)
+		result, response, err := api.New().GetJSON("/api/zones/list", nil)
 		if err != nil {
-			fmt.Printf("Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Printf("Invalid response: %v\n", err)
-			os.Exit(1)
-		}
-
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
@@ -52,7 +31,6 @@ var listCmd = &cobra.Command{
 			return
 		}
 
-		response := result["response"].(map[string]interface{})
 		zones := response["zones"].([]interface{})
 
 		bold := color.New(color.Bold).SprintFunc()

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,15 +1,15 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var outputPath string
@@ -25,34 +25,13 @@ var logsListCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List available log files",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
-		url := fmt.Sprintf("%s/api/logs/list?token=%s", host, token)
-
-		resp, err := http.Get(url)
+		_, response, err := api.New().GetJSON("/api/logs/list", nil)
 		if err != nil {
-			fmt.Printf("Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Printf("Invalid response: %v\n", err)
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
-			os.Exit(1)
-		}
-
-		logs := result["response"].(map[string]interface{})["logFiles"].([]interface{})
+		logs := response["logFiles"].([]interface{})
 		if len(logs) == 0 {
 			fmt.Println("No log files found.")
 			return
@@ -75,12 +54,9 @@ var logsDownloadCmd = &cobra.Command{
 	Short:   "Download a specific log file",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
 		fileName := args[0]
 
-		url := fmt.Sprintf("%s/api/logs/download?token=%s&fileName=%s", host, token, fileName)
-		resp, err := http.Get(url)
+		resp, err := api.New().Get("/api/logs/download", url.Values{"fileName": {fileName}})
 		if err != nil {
 			fmt.Printf("Request failed: %v\n", err)
 			os.Exit(1)
@@ -118,30 +94,10 @@ var logsDeleteCmd = &cobra.Command{
 	Short:   "Delete a specific log file",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
 		fileName := args[0]
 
-		url := fmt.Sprintf("%s/api/logs/delete?token=%s&log=%s", host, token, fileName)
-		resp, err := http.Get(url)
-		if err != nil {
-			fmt.Printf("Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Printf("Invalid response: %v\n", err)
-			os.Exit(1)
-		}
-
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
+		if _, _, err := api.New().GetJSON("/api/logs/delete", url.Values{"log": {fileName}}); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
@@ -154,9 +110,6 @@ var logsDeleteAllCmd = &cobra.Command{
 	Aliases: []string{"da"},
 	Short:   "Delete all log files",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
 		fmt.Print("Are you sure you want to delete ALL logs? (yes/no): ")
 		var confirm string
 		fmt.Scanln(&confirm)
@@ -165,26 +118,8 @@ var logsDeleteAllCmd = &cobra.Command{
 			return
 		}
 
-		url := fmt.Sprintf("%s/api/logs/deleteAll?token=%s", host, token)
-		resp, err := http.Get(url)
-		if err != nil {
-			fmt.Printf("Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Printf("Invalid response: %v\n", err)
-			os.Exit(1)
-		}
-
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
+		if _, _, err := api.New().GetJSON("/api/logs/deleteAll", nil); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 

--- a/cmd/records.go
+++ b/cmd/records.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var (
@@ -18,7 +20,6 @@ var (
 	assumeYes  bool
 	zoneName   string
 	recordTTL  int
-	rTTL       string
 	ipAddress  string
 	cnameValue string
 	domainName string
@@ -30,31 +31,15 @@ var recordsGetCmd = &cobra.Command{
 	Short:   "List all DNS records for a zone",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
 		zone := args[0]
-		url := fmt.Sprintf("%s/api/zones/records/get?token=%s&domain=%s&zone=%s&listZone=true", host, token, zone, zone)
-
-		resp, err := http.Get(url)
+		q := url.Values{
+			"domain":   {zone},
+			"zone":     {zone},
+			"listZone": {"true"},
+		}
+		result, response, err := api.New().GetJSON("/api/zones/records/get", q)
 		if err != nil {
-			fmt.Printf("Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Printf("Invalid response: %v\n", err)
-			os.Exit(1)
-		}
-
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
@@ -62,12 +47,6 @@ var recordsGetCmd = &cobra.Command{
 			raw, _ := json.MarshalIndent(result, "", "  ")
 			fmt.Println(string(raw))
 			return
-		}
-
-		response, ok := result["response"].(map[string]interface{})
-		if !ok {
-			fmt.Println("Unexpected response structure")
-			os.Exit(1)
 		}
 
 		records, ok := response["records"].([]interface{})
@@ -88,16 +67,10 @@ var recordsGetCmd = &cobra.Command{
 			ttl := rec["ttl"]
 			recordValue := "None"
 			if rVal, ok := rec["rData"]; ok && rVal != nil {
-				//recordValue = fmt.Sprintf("%v", rVal)
-				recordValue = fmt.Sprintf("%s", FormatMap(rVal))
+				recordValue = FormatMap(rVal)
 			}
 
-			fmt.Printf("%s  %s  %g  %s\n",
-				greenL(name),
-				rtype,
-				ttl,
-				recordValue,
-			)
+			fmt.Printf("%s  %s  %g  %s\n", greenL(name), rtype, ttl, recordValue)
 		}
 	},
 }
@@ -108,55 +81,40 @@ var recordsCmd = &cobra.Command{
 	Short:   "Manage zone records",
 }
 
+func recordQuery() url.Values {
+	q := url.Values{
+		"domain": {domainName},
+		"zone":   {zoneName},
+		"type":   {recordType},
+	}
+	if recordTTL >= 0 {
+		q.Set("ttl", strconv.Itoa(recordTTL))
+	}
+	if ipAddress != "" {
+		q.Set("ipAddress", ipAddress)
+	}
+	if cnameValue != "" {
+		q.Set("cname", cnameValue)
+	}
+	return q
+}
+
 var recordsAddCmd = &cobra.Command{
 	Use:     "add",
 	Aliases: []string{"a"},
 	Short:   "Add a new record to a zone",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
 		if zoneName == "" || recordType == "" {
 			fmt.Fprintln(os.Stderr, "❌ --zone and --type are required")
 			os.Exit(1)
 		}
 
-		if recordTTL < 0 {
-			rTTL = ""
-		} else {
-			rTTL = fmt.Sprintf("&ttl=%d", recordTTL)
-		}
+		q := recordQuery()
+		q.Set("overwrite", strconv.FormatBool(overwrite))
 
-		url := fmt.Sprintf("%s/api/zones/records/add?token=%s&domain=%s&zone=%s&type=%s%s",
-			host, token, domainName, zoneName, recordType, rTTL)
-		url += fmt.Sprintf("&overwrite=%t", overwrite)
-
-		if ipAddress != "" {
-			url += fmt.Sprintf("&ipAddress=%s", ipAddress)
-		}
-		if cnameValue != "" {
-			url += fmt.Sprintf("&cname=%s", cnameValue)
-		}
-
-		resp, err := http.Get(url)
+		result, _, err := api.New().GetJSON("/api/zones/records/add", q)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Failed to parse response: %v\n", err)
-			os.Exit(1)
-		}
-
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
@@ -173,28 +131,9 @@ var recordsDeleteCmd = &cobra.Command{
 	Aliases: []string{"d", "del"},
 	Short:   "Delete a record from a zone",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
 		if zoneName == "" || recordType == "" {
 			fmt.Fprintln(os.Stderr, "❌ --zone and --type are required")
 			os.Exit(1)
-		}
-
-		if recordTTL < 0 {
-			rTTL = ""
-		} else {
-			rTTL = fmt.Sprintf("&ttl=%d", recordTTL)
-		}
-
-		url := fmt.Sprintf("%s/api/zones/records/delete?token=%s&domain=%s&zone=%s&type=%s%s",
-			host, token, domainName, zoneName, recordType, rTTL)
-
-		if ipAddress != "" {
-			url += fmt.Sprintf("&ipAddress=%s", ipAddress)
-		}
-		if cnameValue != "" {
-			url += fmt.Sprintf("&cname=%s", cnameValue)
 		}
 
 		if !assumeYes {
@@ -207,25 +146,8 @@ var recordsDeleteCmd = &cobra.Command{
 			}
 		}
 
-		resp, err := http.Get(url)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Failed to parse response: %v\n", err)
-			os.Exit(1)
-		}
-
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok {
-				fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-			} else {
-				fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-			}
+		if _, _, err := api.New().GetJSON("/api/zones/records/delete", recordQuery()); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 

--- a/cmd/resync.go
+++ b/cmd/resync.go
@@ -1,14 +1,14 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var resyncZoneCmd = &cobra.Command{
@@ -16,36 +16,16 @@ var resyncZoneCmd = &cobra.Command{
 	Short: "Resynchronize one or more DNS zones",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
 		bold := color.New(color.Bold).SprintFunc()
 		amber := color.New(color.FgYellow).SprintFunc()
 
+		client := api.New()
 		for _, zone := range args {
-			url := fmt.Sprintf("%s/api/zones/resync?token=%s&zone=%s", host, token, zone)
-			resp, err := http.Get(url)
+			_, _, err := client.GetJSON("/api/zones/resync", url.Values{"zone": {zone}})
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "❌ Failed to resync zone %s: %v\n", amber(zone), err)
-				continue
-			}
-			defer resp.Body.Close()
-
-			var result map[string]interface{}
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				fmt.Fprintf(os.Stderr, "❌ Invalid response: %v\n", err)
 				os.Exit(1)
 			}
-
-			if status, ok := result["status"].(string); !ok || status != "ok" {
-				if msg, ok := result["errorMessage"].(string); ok {
-					fmt.Fprintf(os.Stderr, "❌ %s\n", msg)
-				} else {
-					fmt.Fprintln(os.Stderr, "❌ Unexpected API error")
-				}
-				os.Exit(1)
-			}
-
 			fmt.Printf("✅ Zone %v resynced successfully.\n", bold(zone))
 		}
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 // Name & Version of the app
@@ -37,8 +39,6 @@ var rootCmd = &cobra.Command{
 
 func Execute(version string) {
 	Version = version
-	// fmt.Println()
-	// defer fmt.Println()
 
 	rootCmd.Version = version
 
@@ -59,8 +59,12 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&debugFlag, "debug", "d", false, "Enable debugging logging")
 	rootCmd.PersistentFlags().StringP("token", "t", "", "API token (overrides config/TDNS_API_TOKEN env)")
 	rootCmd.PersistentFlags().StringP("endpoint", "e", "", "API endpoint (overrides config)")
+	rootCmd.PersistentFlags().BoolP("legacy-token", "L", false, "Also send token as a query parameter (for older servers/endpoints that don't honor Authorization: Bearer)")
+	rootCmd.PersistentFlags().DurationP("timeout", "T", api.DefaultTimeout, "API request timeout (e.g. 5s, 1m)")
 	viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token"))
 	viper.BindPFlag("host", rootCmd.PersistentFlags().Lookup("endpoint"))
+	viper.BindPFlag("legacy_token", rootCmd.PersistentFlags().Lookup("legacy-token"))
+	viper.BindPFlag("timeout", rootCmd.PersistentFlags().Lookup("timeout"))
 
 	viper.SetEnvPrefix("TDNS")
 	viper.AutomaticEnv()

--- a/cmd/server_version.go
+++ b/cmd/server_version.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"tdns/internal/api"
+)
+
+var serverVersionCmd = &cobra.Command{
+	Use:     "server-version",
+	Aliases: []string{"sv"},
+	Short:   "Print the version of the connected DNS server",
+	Run: func(cmd *cobra.Command, args []string) {
+		v, err := api.New().ServerVersion()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(v)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(serverVersionCmd)
+}

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -7,19 +7,40 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/fatih/color"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var getJSON bool
 
 var backupOutputPath string
+
+// fullBackupQuery is the query-string set used for both backup and restore.
+func fullBackupQuery(extra map[string]string) url.Values {
+	q := url.Values{
+		"blockLists":   {"true"},
+		"logs":         {"true"},
+		"scopes":       {"true"},
+		"stats":        {"true"},
+		"zones":        {"true"},
+		"allowedZones": {"true"},
+		"blockedZones": {"true"},
+		"dnsSettings":  {"true"},
+		"logSettings":  {"true"},
+		"authConfig":   {"true"},
+	}
+	for k, v := range extra {
+		q.Set(k, v)
+	}
+	return q
+}
 
 var settingsCmd = &cobra.Command{
 	Use:     "settings",
@@ -32,12 +53,7 @@ var settingsBackupCmd = &cobra.Command{
 	Aliases: []string{"ba"},
 	Short:   "Download a backup zip file of selected server settings",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
-		url := fmt.Sprintf("%s/api/settings/backup?token=%s&blockLists=true&logs=true&scopes=true&stats=true&zones=true&allowedZones=true&blockedZones=true&dnsSettings=true&logSettings=true&authConfig=true", host, token)
-
-		resp, err := http.Get(url)
+		resp, err := api.New().Get("/api/settings/backup", fullBackupQuery(nil))
 		if err != nil {
 			fmt.Printf("Request failed: %v\n", err)
 			os.Exit(1)
@@ -90,9 +106,6 @@ var settingsRestoreCmd = &cobra.Command{
 	Aliases: []string{"re"},
 	Short:   "Restore server settings from a backup zip file",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
 		if restoreInputPath == "" {
 			fmt.Fprintln(os.Stderr, "❌ --input is required")
 			os.Exit(1)
@@ -119,16 +132,8 @@ var settingsRestoreCmd = &cobra.Command{
 		}
 		writer.Close()
 
-		url := fmt.Sprintf("%s/api/settings/restore?token=%s&blockLists=true&logs=true&scopes=true&stats=true&zones=true&allowedZones=true&blockedZones=true&dnsSettings=true&logSettings=true&deleteExistingFiles=true&authConfig=true", host, token)
-		req, err := http.NewRequest("POST", url, body)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Failed to create request: %v\n", err)
-			os.Exit(1)
-		}
-		req.Header.Set("Content-Type", writer.FormDataContentType())
-
-		client := &http.Client{}
-		resp, err := client.Do(req)
+		q := fullBackupQuery(map[string]string{"deleteExistingFiles": "true"})
+		resp, err := api.New().Post("/api/settings/restore", q, body, writer.FormDataContentType())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "❌ Request failed: %v\n", err)
 			os.Exit(1)
@@ -204,43 +209,22 @@ var settingsGetCmd = &cobra.Command{
 	Aliases: []string{"ge"},
 	Short:   "Retrieve current server settings",
 	Run: func(cmd *cobra.Command, args []string) {
-		token := viper.GetString("token")
-		host := viper.GetString("host")
-
-		url := fmt.Sprintf("%s/api/settings/get?token=%s", host, token)
-
-		resp, err := http.Get(url)
+		result, response, err := api.New().GetJSON("/api/settings/get", nil)
 		if err != nil {
-			fmt.Printf("❌ Request failed: %v\n", err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			fmt.Fprintf(os.Stderr, "❌ Failed: HTTP %d\n", resp.StatusCode)
-			os.Exit(1)
-		}
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Failed to parse response: %v\n", err)
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
 		if getJSON {
 			raw, _ := json.MarshalIndent(result, "", "  ")
 			fmt.Println(string(raw))
-
 			return
 		}
-
-		response := result["response"].(map[string]interface{})
 
 		bold := color.New(color.Bold).SprintFunc()
 		cyan := color.New(color.FgCyan).SprintFunc()
 		green := color.New(color.FgGreen).SprintFunc()
 		yellow := color.New(color.FgYellow).SprintFunc()
-		//gray := color.New(color.FgHiBlack).SprintFunc()
 
 		fmt.Println(bold("General Settings:"))
 		fmt.Printf("  Version: %s\n", green(response["version"]))

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:     "version",
+	Aliases: []string{"ver"},
+	Short:   "Print client version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(Version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/zone_get_options.go
+++ b/cmd/zone_get_options.go
@@ -3,14 +3,16 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
+	"net/url"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 type sprinter func(a ...interface{}) string
@@ -27,8 +29,6 @@ var getZoneOptionsCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		zone := args[0]
-		token := viper.GetString("token")
-		host := viper.GetString("host")
 
 		// Colors & styles to match existing CLI look-and-feel
 		bold := color.New(color.Bold).SprintFunc()
@@ -38,35 +38,13 @@ var getZoneOptionsCmd = &cobra.Command{
 		red := color.New(color.FgRed).SprintFunc()
 		gray := color.New(color.FgHiBlack).SprintFunc()
 
-		url := fmt.Sprintf("%s/api/zones/options/get?token=%s&zone=%s&includeAvailableTsigKeyNames=%t",
-			host, token, zone, includeAvailableKeys)
-
-		resp, err := http.Get(url)
+		q := url.Values{
+			"zone":                         {zone},
+			"includeAvailableTsigKeyNames": {strconv.FormatBool(includeAvailableKeys)},
+		}
+		_, respObj, err := api.New().GetJSON("/api/zones/options/get", q)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s request failed: %v\n", red("❌"), err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Fprintf(os.Stderr, "%s invalid response: %v\n", red("❌"), err)
-			os.Exit(1)
-		}
-
-		// If status != ok, print only errorMessage (if present), else generic
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok && strings.TrimSpace(msg) != "" {
-				fmt.Fprintln(os.Stderr, red("❌ ")+msg)
-			} else {
-				fmt.Fprintln(os.Stderr, red("❌ Unexpected API error"))
-			}
-			os.Exit(1)
-		}
-
-		respObj, ok := result["response"].(map[string]interface{})
-		if !ok {
-			fmt.Fprintln(os.Stderr, red("❌ Unexpected response structure"))
+			fmt.Fprintf(os.Stderr, "%s %v\n", red("❌"), err)
 			os.Exit(1)
 		}
 

--- a/cmd/zone_set_options.go
+++ b/cmd/zone_set_options.go
@@ -6,14 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+
+	"tdns/internal/api"
 )
 
 var (
@@ -36,8 +36,6 @@ var setZoneOptionsCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		zone := args[0]
-		token := viper.GetString("token")
-		host := viper.GetString("host")
 
 		// styles
 		bold := color.New(color.Bold).SprintFunc()
@@ -83,7 +81,6 @@ var setZoneOptionsCmd = &cobra.Command{
 
 		// 2) Build query params from base payload first
 		q := url.Values{}
-		q.Set("token", token)
 		q.Set("zone", zone)
 
 		// Helper to set a key from "base" map if present
@@ -139,34 +136,15 @@ var setZoneOptionsCmd = &cobra.Command{
 			q.Set("notifyNameServers", joinCSV(flagNotifyNameServers))
 		}
 
-		// If only token/zone are present, nothing was set
-		if len(q) <= 2 {
+		// If only zone is present, nothing was set
+		if len(q) <= 1 {
 			fmt.Fprintln(os.Stderr, red("❌ no options provided — use flags and/or --data-file/--stdin"))
 			os.Exit(1)
 		}
 
 		// 4) Call API with query params (GET, per API expectation)
-		endpoint := fmt.Sprintf("%s/api/zones/options/set?%s", host, q.Encode())
-		resp, err := http.Get(endpoint)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s request failed: %v\n", red("❌"), err)
-			os.Exit(1)
-		}
-		defer resp.Body.Close()
-
-		var result map[string]interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			fmt.Fprintf(os.Stderr, "%s invalid response: %v\n", red("❌"), err)
-			os.Exit(1)
-		}
-
-		// If status != ok, print only errorMessage (if present), else generic
-		if status, ok := result["status"].(string); !ok || status != "ok" {
-			if msg, ok := result["errorMessage"].(string); ok && strings.TrimSpace(msg) != "" {
-				fmt.Fprintln(os.Stderr, red("❌ ")+msg)
-			} else {
-				fmt.Fprintln(os.Stderr, red("❌ Unexpected API error"))
-			}
+		if _, _, err := api.New().GetJSON("/api/zones/options/set", q); err != nil {
+			fmt.Fprintf(os.Stderr, "%s %v\n", red("❌"), err)
 			os.Exit(1)
 		}
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,0 +1,210 @@
+// Package api is a thin HTTP client for the Technitium DNS Server API.
+//
+// It targets v15+, sending the session token via the
+// `Authorization: Bearer <token>` header. For older servers (or endpoints
+// that haven't been updated to honor the header), set viper key
+// `legacy_token` (CLI flag `--legacy-token`) to also emit the token as a
+// `token=` query/form parameter.
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// DefaultTimeout is used when neither the `timeout` viper key nor a custom
+// HTTP client is provided. It bounds total request time including connect,
+// TLS handshake, redirects, and reading the response body.
+const DefaultTimeout = 5 * time.Second
+
+// Client talks to a Technitium DNS Server HTTP API.
+type Client struct {
+	Host        string
+	Token       string
+	HTTP        *http.Client
+	Timeout     time.Duration
+	LegacyToken bool // when true, also append `token=` to the query string
+}
+
+// New builds a Client from viper config (host, token, legacy_token, timeout).
+func New() *Client {
+	timeout := DefaultTimeout
+	if d := viper.GetDuration("timeout"); d > 0 {
+		timeout = d
+	}
+	return &Client{
+		Host:        viper.GetString("host"),
+		Token:       viper.GetString("token"),
+		LegacyToken: viper.GetBool("legacy_token"),
+		Timeout:     timeout,
+		HTTP:        &http.Client{Timeout: timeout},
+	}
+}
+
+func (c *Client) buildURL(path string, q url.Values) string {
+	host := strings.TrimRight(c.Host, "/")
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if c.LegacyToken && c.Token != "" {
+		if q == nil {
+			q = url.Values{}
+		}
+		if q.Get("token") == "" {
+			q.Set("token", c.Token)
+		}
+	}
+	if len(q) == 0 {
+		return host + path
+	}
+	return host + path + "?" + q.Encode()
+}
+
+func (c *Client) newRequest(method, path string, q url.Values, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, c.buildURL(path, q), body)
+	if err != nil {
+		return nil, err
+	}
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+	return req, nil
+}
+
+// Do executes a pre-built request after attaching the Bearer auth header.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	if c.Token != "" && req.Header.Get("Authorization") == "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+	return c.do(req)
+}
+
+// Get issues a GET against the API.
+func (c *Client) Get(path string, q url.Values) (*http.Response, error) {
+	req, err := c.newRequest(http.MethodGet, path, q, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.do(req)
+}
+
+// Post issues a POST with the given body.
+func (c *Client) Post(path string, q url.Values, body io.Reader, contentType string) (*http.Response, error) {
+	req, err := c.newRequest(http.MethodPost, path, q, body)
+	if err != nil {
+		return nil, err
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return c.do(req)
+}
+
+// do is the single chokepoint where transport errors are inspected. It wraps
+// timeout errors in a TimeoutError so the CLI can print a friendly message.
+func (c *Client) do(req *http.Request) (*http.Response, error) {
+	resp, err := c.HTTP.Do(req)
+	if err != nil && isTimeout(err) {
+		return resp, &TimeoutError{Timeout: c.Timeout, Err: err}
+	}
+	return resp, err
+}
+
+// TimeoutError indicates the request exceeded the client timeout.
+type TimeoutError struct {
+	Timeout time.Duration
+	Err     error
+}
+
+func (e *TimeoutError) Error() string {
+	return fmt.Sprintf("request timed out after %s (set --timeout to override)", e.Timeout)
+}
+
+func (e *TimeoutError) Unwrap() error { return e.Err }
+
+func isTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ue *url.Error
+	if errors.As(err, &ue) && ue.Timeout() {
+		return true
+	}
+	type timeoutIface interface{ Timeout() bool }
+	var t timeoutIface
+	if errors.As(err, &t) && t.Timeout() {
+		return true
+	}
+	return false
+}
+
+// APIError is returned when the API responds with status != "ok".
+type APIError struct {
+	Status  string
+	Message string
+}
+
+func (e *APIError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return "unexpected API error"
+}
+
+// GetJSON issues a GET, decodes the envelope, and returns both the full
+// envelope and the inner "response" object. It returns *APIError when the
+// server reports a non-ok status.
+func (c *Client) GetJSON(path string, q url.Values) (map[string]interface{}, map[string]interface{}, error) {
+	resp, err := c.Get(path, q)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+	return decodeEnvelope(resp.Body)
+}
+
+// DoJSON executes the request and decodes the JSON envelope.
+func (c *Client) DoJSON(req *http.Request) (map[string]interface{}, map[string]interface{}, error) {
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+	return decodeEnvelope(resp.Body)
+}
+
+// ServerVersion fetches the connected server's version string by calling
+// /api/settings/get and reading its `version` field.
+func (c *Client) ServerVersion() (string, error) {
+	_, response, err := c.GetJSON("/api/settings/get", nil)
+	if err != nil {
+		return "", err
+	}
+	v, _ := response["version"].(string)
+	if v == "" {
+		return "", fmt.Errorf("server did not return a version field")
+	}
+	return v, nil
+}
+
+func decodeEnvelope(r io.Reader) (map[string]interface{}, map[string]interface{}, error) {
+	var result map[string]interface{}
+	if err := json.NewDecoder(r).Decode(&result); err != nil {
+		return nil, nil, fmt.Errorf("invalid response: %w", err)
+	}
+	status, _ := result["status"].(string)
+	if status != "ok" {
+		msg, _ := result["errorMessage"].(string)
+		return result, nil, &APIError{Status: status, Message: msg}
+	}
+	response, _ := result["response"].(map[string]interface{})
+	return result, response, nil
+}


### PR DESCRIPTION
* Technitium DNS Server v15.0 supports passing the session token via the HTTP `Authorization: Bearer <token>` header instead of the `token=` query parameter. Switch all API calls to use the header form via small helpers (apiGet/apiDo/apiNewRequest) in cmd/util.go. The legacy query parameter cna be used using `-L`
* add `version command
* refactor API handling 
* add connection timeout