### PR TITLE
feat: align change-password with upstream API

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Lint
       run: |
         #go mod tidy
-        make fmt
+        make fmt-check
         make vet
         #go get -u golang.org/x/lint/golint
         #make lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 ### Changed
 - Renamed `--type` to `--filter` for consistency
 - Added confirmation for destructive actions
+- `admin change-password`: align with upstream Technitium API. Now requires
+  current password (`-c`/`--current`) plus new password (`-n`/`--new`), with
+  optional `-o`/`--totp` and `--iterations` flags. Replaces the previous
+  single `-p`/`--pass` flag.
 
 ### Fixed
 - Removed redundant fallback checks across command files

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help vendor build clean help
+.PHONY: help vendor build clean clean-vendor clean-cache tidy run snapshot dev test fmt fmt-check lint vet
 .DEFAULT: help
 ifndef VERBOSE
 .SILENT:
@@ -64,8 +64,16 @@ dev: clean ## Dev test target
 test: vendor ## Run tests
 	go test -v ./...
 
-fmt: **/*.go ## Formt Golang code
+fmt: **/*.go ## Format Golang code
 	go fmt ./...
+
+fmt-check: ## Fail if Go code is not gofmt-clean
+	@unformatted=$$(gofmt -l .); \
+	if [ -n "$$unformatted" ]; then \
+		echo "The following files are not gofmt-clean:"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
 
 lint:
 	golint ./...

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ tdns logs deleteAll
 tdns admin list-sessions
 tdns admin delete-session --id <partialToken>
 tdns admin create-token --user admin --token-name mytoken
-tdns admin change-password -i [-p <pass>]
+tdns admin change-password -i [-c <current>] [-n <new>] [-o <totp>] [--iterations <n>]
 tdns admin check-update [--json]
 ```
 

--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -25,6 +25,9 @@ var createTokenUser string
 var createTokenName string
 var getUser string
 var newPassword string
+var currentPassword string
+var totpCode string
+var pbkdf2Iterations int
 var interactive bool
 var JSON bool
 
@@ -251,32 +254,61 @@ var adminChangePasswordCmd = &cobra.Command{
 	Aliases: []string{"cp"},
 	Short:   "Change the current user's password",
 	Run: func(cmd *cobra.Command, args []string) {
-		if newPassword == "" && interactive {
-			fmt.Print("Enter new password: ")
-			bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
-			fmt.Println()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "❌ Failed to read password: %v\n", err)
-				os.Exit(1)
+		if interactive {
+			if currentPassword == "" {
+				fmt.Print("Enter current password: ")
+				byteCurrent, err := term.ReadPassword(int(os.Stdin.Fd()))
+				fmt.Println()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "❌ Failed to read password: %v\n", err)
+					os.Exit(1)
+				}
+				currentPassword = string(byteCurrent)
 			}
 
-			fmt.Print("Confirm new password: ")
-			byteConfirm, _ := term.ReadPassword(int(os.Stdin.Fd()))
-			fmt.Println()
-			if string(byteConfirm) != string(bytePassword) {
-				fmt.Fprintln(os.Stderr, "❌ Passwords do not match")
-				os.Exit(1)
-			}
+			if newPassword == "" {
+				fmt.Print("Enter new password: ")
+				bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
+				fmt.Println()
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "❌ Failed to read password: %v\n", err)
+					os.Exit(1)
+				}
 
-			newPassword = string(bytePassword)
+				fmt.Print("Confirm new password: ")
+				byteConfirm, _ := term.ReadPassword(int(os.Stdin.Fd()))
+				fmt.Println()
+				if string(byteConfirm) != string(bytePassword) {
+					fmt.Fprintln(os.Stderr, "❌ Passwords do not match")
+					os.Exit(1)
+				}
+
+				newPassword = string(bytePassword)
+			}
 		}
 
-		if newPassword == "" {
-			fmt.Fprintln(os.Stderr, "❌ --pass is required")
+		if currentPassword == "" {
+			fmt.Fprintln(os.Stderr, "❌ --current is required")
 			os.Exit(1)
 		}
 
-		if _, _, err := api.New().GetJSON("/api/user/changePassword", url.Values{"pass": {newPassword}}); err != nil {
+		if newPassword == "" {
+			fmt.Fprintln(os.Stderr, "❌ --new is required")
+			os.Exit(1)
+		}
+
+		params := url.Values{
+			"pass":    {currentPassword},
+			"newPass": {newPassword},
+		}
+		if totpCode != "" {
+			params.Set("totp", totpCode)
+		}
+		if pbkdf2Iterations > 0 {
+			params.Set("iterations", fmt.Sprintf("%d", pbkdf2Iterations))
+		}
+
+		if _, _, err := api.New().GetJSON("/api/user/changePassword", params); err != nil {
 			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
@@ -287,7 +319,10 @@ var adminChangePasswordCmd = &cobra.Command{
 
 func init() {
 	adminChangePasswordCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "Prompt for password interactively")
-	adminChangePasswordCmd.Flags().StringVarP(&newPassword, "pass", "p", "", "New password (insecure)")
+	adminChangePasswordCmd.Flags().StringVarP(&currentPassword, "current", "c", "", "Current password (insecure)")
+	adminChangePasswordCmd.Flags().StringVarP(&newPassword, "new", "n", "", "New password (insecure)")
+	adminChangePasswordCmd.Flags().StringVarP(&totpCode, "totp", "o", "", "6-digit TOTP code if 2FA is enabled")
+	adminChangePasswordCmd.Flags().IntVar(&pbkdf2Iterations, "iterations", 0, "Number of iterations for PBKDF2 SHA256 password hashing")
 	adminCmd.AddCommand(adminChangePasswordCmd)
 	adminCmd.AddCommand(adminCheckUpdateCmd)
 	adminCheckUpdateCmd.Flags().BoolVar(&JSON, "json", false, "Output raw JSON response")

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -15,13 +15,13 @@ import (
 
 func TestBuildURL(t *testing.T) {
 	tests := []struct {
-		name        string
-		host        string
-		path        string
-		token       string
-		legacy      bool
-		query       url.Values
-		want        string
+		name   string
+		host   string
+		path   string
+		token  string
+		legacy bool
+		query  url.Values
+		want   string
 	}{
 		{
 			name: "trailing slash trimmed",


### PR DESCRIPTION
* The Technitium /api/user/changePassword endpoint requires both the current password (pass) and the new password (newPass), with optional totp and iterations parameters. Update the command to send the correct parameters and expose --current/--new/--totp/--iterations flags.
* docs: note change-password API alignment in CHANGELOG