### PR TITLE
feat(list): support zones list filtering and pagination (API v15.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can also use:
 ### Zones
 
 ```bash
-tdns list [--json]
+tdns list [--name 'example.*'] [--type Primary] [--page 1 --per-page 10] [--json]
 tdns import <zone> --file zone.txt [--json]
 tdns export <zone> [--output-dir dir] [--json]
 tdns create <zone>... [--type Primary]

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,8 +3,12 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
+	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -12,14 +16,205 @@ import (
 	"tdns/internal/api"
 )
 
-var listJSON bool
+var (
+	listJSON       bool
+	listFilterName string
+	listFilterType string
+	listPage       int
+	listPerPage    int
+)
+
+// zoneTypes are the valid values for the API's filterType parameter.
+var zoneTypes = []string{"Primary", "Secondary", "Stub", "Forwarder", "SecondaryForwarder", "Catalog", "SecondaryCatalog"}
+
+// canonicalZoneType matches t against zoneTypes case-insensitively and
+// returns the server's canonical spelling.
+func canonicalZoneType(t string) (string, bool) {
+	for _, v := range zoneTypes {
+		if strings.EqualFold(v, t) {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// matchWildcard reports whether name matches pattern case-insensitively,
+// where `*` matches zero or more characters and `?` matches exactly one.
+// It mirrors the server-side filterName semantics (added in v15.3) so that
+// filtering also works against older servers that ignore the parameter.
+func matchWildcard(pattern, name string) bool {
+	var sb strings.Builder
+	sb.WriteString("(?i)^")
+	for _, r := range pattern {
+		switch r {
+		case '*':
+			sb.WriteString(".*")
+		case '?':
+			sb.WriteString(".")
+		default:
+			sb.WriteString(regexp.QuoteMeta(string(r)))
+		}
+	}
+	sb.WriteString("$")
+	re, err := regexp.Compile(sb.String())
+	if err != nil {
+		return false
+	}
+	return re.MatchString(name)
+}
+
+// buildZonesListQuery translates the list flags into /api/zones/list query
+// parameters. It returns nil when no flag is set so a plain `tdns list`
+// sends the same request as before these options existed.
+func buildZonesListQuery(filterName, filterType string, page, perPage int) url.Values {
+	q := url.Values{}
+	if filterName != "" {
+		q.Set("filterName", filterName)
+	}
+	if filterType != "" {
+		q.Set("filterType", filterType)
+	}
+	if page > 0 {
+		q.Set("pageNumber", strconv.Itoa(page))
+	}
+	if perPage > 0 {
+		q.Set("zonesPerPage", strconv.Itoa(perPage))
+	}
+	if len(q) == 0 {
+		return nil
+	}
+	return q
+}
+
+// filterZones applies filterName/filterType to zones client-side. Servers
+// v15.3+ already filter, making this a no-op; older servers ignore the
+// parameters and return everything, so this keeps the flags working there.
+func filterZones(zones []interface{}, filterName, filterType string) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, len(zones))
+	for _, z := range zones {
+		zone, ok := z.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := zone["name"].(string)
+		if filterName != "" && !matchWildcard(filterName, name) {
+			continue
+		}
+		if filterType != "" {
+			if zt, _ := zone["type"].(string); !strings.EqualFold(zt, filterType) {
+				continue
+			}
+		}
+		out = append(out, zone)
+	}
+	return out
+}
+
+// formatZonesList renders the zones/list response body. Fields are read
+// tolerantly so responses from older or newer server versions render
+// without panicking. showFooter adds the pagination summary when the
+// response carries one.
+func formatZonesList(response map[string]interface{}, filterName, filterType string, showFooter bool) string {
+	bold := color.New(color.Bold).SprintFunc()
+	red := color.New(color.FgRed).SprintFunc()
+	green := color.New(color.FgGreen).SprintFunc()
+	blue := color.New(color.FgBlue).SprintFunc()
+	gray := color.New(color.FgHiBlack).SprintFunc()
+	amber := color.New(color.FgYellow).SprintFunc()
+
+	rawZones, _ := response["zones"].([]interface{})
+	zones := filterZones(rawZones, filterName, filterType)
+
+	names := make([]string, 0, len(zones))
+	zoneMap := make(map[string]map[string]interface{})
+	for _, zone := range zones {
+		name, _ := zone["name"].(string)
+		names = append(names, name)
+		zoneMap[name] = zone
+	}
+	sort.Strings(names)
+
+	var sb strings.Builder
+	if len(names) == 0 {
+		sb.WriteString("No zones found.\n")
+	}
+
+	for _, name := range names {
+		zone := zoneMap[name]
+		ztype, _ := zone["type"].(string)
+
+		status := green("Enabled")
+		if disabled, _ := zone["disabled"].(bool); disabled {
+			status = red("Disabled")
+		}
+
+		scope := gray("External")
+		if internal, ok := zone["internal"].(bool); ok && internal {
+			scope = blue("Internal")
+		}
+
+		dnssec := amber("Unsigned")
+		if s, ok := zone["dnssecStatus"].(string); ok && s != "" {
+			dnssec = amber(s)
+		}
+
+		health := ""
+		if expired, _ := zone["isExpired"].(bool); expired {
+			health += " | " + red("Expired")
+		}
+		if failed, _ := zone["syncFailed"].(bool); failed {
+			health += " | " + red("Sync failed")
+		}
+		if failed, _ := zone["notifyFailed"].(bool); failed {
+			health += " | " + amber("Notify failed")
+		}
+
+		fmt.Fprintf(&sb, "%s (%s)\n", bold(name), blue(ztype))
+		if modified, ok := zone["lastModified"].(string); ok {
+			fmt.Fprintf(&sb, "  Last Modified: %s\n", modified)
+		}
+		if serial, ok := zone["soaSerial"].(float64); ok {
+			fmt.Fprintf(&sb, "  SOA Serial: %d\n", int64(serial))
+		}
+		fmt.Fprintf(&sb, "  Status: %s | %s%s\n", status, scope, health)
+		fmt.Fprintf(&sb, "  DNSSEC: %s\n", dnssec)
+		sb.WriteString("\n")
+	}
+
+	if showFooter {
+		if totalPages, ok := response["totalPages"].(float64); ok {
+			pageNumber, _ := response["pageNumber"].(float64)
+			totalZones, _ := response["totalZones"].(float64)
+			fmt.Fprintf(&sb, "%s\n", gray(fmt.Sprintf("Page %.0f/%.0f | %.0f zones total", pageNumber, totalPages, totalZones)))
+		}
+	}
+
+	return sb.String()
+}
 
 var listCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
-	Short:   "List all DNS zones",
+	Short:   "List DNS zones, optionally filtered by name or type",
+	Long: `List DNS zones.
+
+Zones can be filtered by name (--name, supporting * and ? wildcards) and by
+type (--type). Servers v15.3+ filter server-side; on older servers the same
+filter is applied client-side, so the flags work either way. Results can be
+paginated with --page and --per-page.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		result, response, err := api.New().GetJSON("/api/zones/list", nil)
+		filterType := ""
+		if listFilterType != "" {
+			ct, ok := canonicalZoneType(listFilterType)
+			if !ok {
+				fmt.Fprintf(os.Stderr, "❌ invalid zone type %q (valid: %s)\n", listFilterType, strings.Join(zoneTypes, ", "))
+				os.Exit(1)
+			}
+			filterType = ct
+		}
+
+		q := buildZonesListQuery(listFilterName, filterType, listPage, listPerPage)
+		result, response, err := api.New().GetJSON("/api/zones/list", q)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
@@ -31,59 +226,16 @@ var listCmd = &cobra.Command{
 			return
 		}
 
-		zones := response["zones"].([]interface{})
-
-		bold := color.New(color.Bold).SprintFunc()
-		red := color.New(color.FgRed).SprintFunc()
-		green := color.New(color.FgGreen).SprintFunc()
-		blue := color.New(color.FgBlue).SprintFunc()
-		gray := color.New(color.FgHiBlack).SprintFunc()
-		amber := color.New(color.FgYellow).SprintFunc()
-
-		names := make([]string, 0, len(zones))
-		zoneMap := make(map[string]map[string]interface{})
-
-		for _, z := range zones {
-			zone := z.(map[string]interface{})
-			name := zone["name"].(string)
-			names = append(names, name)
-			zoneMap[name] = zone
-		}
-
-		sort.Strings(names)
-
-		for _, name := range names {
-			zone := zoneMap[name]
-			ztype := zone["type"].(string)
-			serial := int64(zone["soaSerial"].(float64))
-			modified := zone["lastModified"].(string)
-
-			status := green("Enabled")
-			if zone["disabled"].(bool) {
-				status = red("Disabled")
-			}
-
-			scope := gray("External")
-			if internal, ok := zone["internal"].(bool); ok && internal {
-				scope = blue("Internal")
-			}
-
-			dnssec := amber("Unsigned")
-			if s, ok := zone["dnssecStatus"].(string); ok && s != "" {
-				dnssec = amber(s)
-			}
-
-			fmt.Printf("%s (%s)\n", bold(name), blue(ztype))
-			fmt.Printf("  Last Modified: %s\n", modified)
-			fmt.Printf("  SOA Serial: %d\n", serial)
-			fmt.Printf("  Status: %s | %s\n", status, scope)
-			fmt.Printf("  DNSSEC: %s\n", dnssec)
-			fmt.Println()
-		}
+		showFooter := listPage > 0 || listPerPage > 0
+		fmt.Print(formatZonesList(response, listFilterName, filterType, showFooter))
 	},
 }
 
 func init() {
 	listCmd.Flags().BoolVar(&listJSON, "json", false, "Output raw JSON response")
+	listCmd.Flags().StringVarP(&listFilterName, "name", "n", "", "Filter zones by name; supports * and ? wildcards")
+	listCmd.Flags().StringVarP(&listFilterType, "type", "y", "", fmt.Sprintf("Filter zones by type (%s)", strings.Join(zoneTypes, ", ")))
+	listCmd.Flags().IntVar(&listPage, "page", 0, "Page number of paginated results (default: all zones)")
+	listCmd.Flags().IntVar(&listPerPage, "per-page", 0, "Zones per page; server default 10 when --page is set")
 	rootCmd.AddCommand(listCmd)
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,226 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestMatchWildcard(t *testing.T) {
+	tests := []struct {
+		pattern, name string
+		want          bool
+	}{
+		{"example.com", "example.com", true},
+		{"example.com", "example.org", false},
+		{"EXAMPLE.com", "example.COM", true}, // case-insensitive
+		{"*", "anything.example.com", true},
+		{"*", "", true},
+		{"*.example.com", "sub.example.com", true},
+		{"*.example.com", "example.com", false},
+		{"example*", "example.com", true},
+		{"exampl?.com", "example.com", true},
+		{"exampl?.com", "exampl.com", false}, // ? is exactly one char
+		{"ex?mple.*", "example.org", true},
+		{"a+b.com", "a+b.com", true},  // regex metachars in pattern are literal
+		{"a+b.com", "aab.com", false}, // and must not act as regex
+		{"", "", true},
+		{"", "example.com", false},
+	}
+	for _, tt := range tests {
+		if got := matchWildcard(tt.pattern, tt.name); got != tt.want {
+			t.Errorf("matchWildcard(%q, %q) = %v, want %v", tt.pattern, tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestCanonicalZoneType(t *testing.T) {
+	for in, want := range map[string]string{
+		"primary":            "Primary",
+		"SECONDARY":          "Secondary",
+		"secondaryforwarder": "SecondaryForwarder",
+		"Catalog":            "Catalog",
+	} {
+		got, ok := canonicalZoneType(in)
+		if !ok || got != want {
+			t.Errorf("canonicalZoneType(%q) = %q, %v; want %q, true", in, got, ok, want)
+		}
+	}
+	if _, ok := canonicalZoneType("bogus"); ok {
+		t.Errorf("canonicalZoneType(\"bogus\") should not match")
+	}
+}
+
+func TestBuildZonesListQuery(t *testing.T) {
+	if q := buildZonesListQuery("", "", 0, 0); q != nil {
+		t.Errorf("expected nil query when no options are set, got %v", q)
+	}
+	q := buildZonesListQuery("ex*", "Primary", 2, 5)
+	for k, want := range map[string]string{
+		"filterName":   "ex*",
+		"filterType":   "Primary",
+		"pageNumber":   "2",
+		"zonesPerPage": "5",
+	} {
+		if got := q.Get(k); got != want {
+			t.Errorf("query %s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestFilterZonesClientSideFallback(t *testing.T) {
+	// Simulates a pre-v15.3 server that ignored filterName/filterType and
+	// returned every zone.
+	zones := []interface{}{
+		map[string]interface{}{"name": "example.com", "type": "Primary"},
+		map[string]interface{}{"name": "sub.example.com", "type": "Secondary"},
+		map[string]interface{}{"name": "other.org", "type": "Primary"},
+		"not-a-zone-object",
+	}
+
+	got := filterZones(zones, "*.example.com", "")
+	if len(got) != 1 || got[0]["name"] != "sub.example.com" {
+		t.Errorf("name filter: got %v, want only sub.example.com", got)
+	}
+
+	got = filterZones(zones, "", "Primary")
+	if len(got) != 2 {
+		t.Errorf("type filter: got %d zones, want 2", len(got))
+	}
+
+	got = filterZones(zones, "*example*", "primary")
+	if len(got) != 1 || got[0]["name"] != "example.com" {
+		t.Errorf("combined filter: got %v, want only example.com", got)
+	}
+
+	if got = filterZones(zones, "", ""); len(got) != 3 {
+		t.Errorf("no filter: got %d zones, want 3", len(got))
+	}
+}
+
+func TestFormatZonesListTolerant(t *testing.T) {
+	// Minimal zone objects (e.g. from a hypothetical older/newer server)
+	// must render without panicking.
+	response := map[string]interface{}{
+		"zones": []interface{}{
+			map[string]interface{}{"name": "bare.example.com"},
+		},
+	}
+	out := formatZonesList(response, "", "", false)
+	if !strings.Contains(out, "bare.example.com") {
+		t.Errorf("output missing zone name: %q", out)
+	}
+	if strings.Contains(out, "SOA Serial") || strings.Contains(out, "Last Modified") {
+		t.Errorf("output should omit absent fields: %q", out)
+	}
+
+	// A response without a zones field must not panic either.
+	out = formatZonesList(map[string]interface{}{}, "", "", false)
+	if !strings.Contains(out, "No zones found.") {
+		t.Errorf("expected empty-list message, got %q", out)
+	}
+}
+
+func TestFormatZonesListFull(t *testing.T) {
+	response := map[string]interface{}{
+		"pageNumber": float64(1),
+		"totalPages": float64(2),
+		"totalZones": float64(12),
+		"zones": []interface{}{
+			map[string]interface{}{
+				"name":         "example.com",
+				"type":         "Secondary",
+				"dnssecStatus": "SignedWithNSEC",
+				"soaSerial":    float64(7),
+				"lastModified": "2022-02-26T07:57:08.1842183Z",
+				"disabled":     true,
+				"isExpired":    true,
+				"syncFailed":   true,
+				"notifyFailed": true,
+			},
+		},
+	}
+	out := formatZonesList(response, "", "", true)
+	for _, want := range []string{
+		"example.com", "Secondary", "SignedWithNSEC", "SOA Serial: 7",
+		"Last Modified: 2022-02-26T07:57:08.1842183Z", "Disabled",
+		"Expired", "Sync failed", "Notify failed", "Page 1/2 | 12 zones total",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+
+	// Footer suppressed when pagination flags were not used.
+	if out := formatZonesList(response, "", "", false); strings.Contains(out, "zones total") {
+		t.Errorf("footer should be hidden when showFooter=false:\n%s", out)
+	}
+}
+
+// runListCmd executes `tdns list <args>` against a stub server and returns
+// the query values the server received.
+func runListCmd(t *testing.T, args ...string) map[string][]string {
+	t.Helper()
+
+	var gotQuery map[string][]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"ok","response":{"zones":[]}}`)
+	}))
+	defer srv.Close()
+
+	oldHost := viper.GetString("host")
+	viper.Set("host", srv.URL)
+	defer viper.Set("host", oldHost)
+
+	// Reset flag-bound package vars from any previous invocation.
+	listJSON = false
+	listFilterName = ""
+	listFilterType = ""
+	listPage = 0
+	listPerPage = 0
+
+	// Silence the command's stdout while it runs.
+	oldStdout := os.Stdout
+	rp, wp, _ := os.Pipe()
+	os.Stdout = wp
+	defer func() { os.Stdout = oldStdout }()
+	go func() { _, _ = io.Copy(io.Discard, rp) }()
+
+	rootCmd.SetArgs(append([]string{"list"}, args...))
+	defer rootCmd.SetArgs(nil)
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("list command failed: %v", err)
+	}
+	wp.Close()
+
+	return gotQuery
+}
+
+func TestListCmdSendsNoParamsByDefault(t *testing.T) {
+	q := runListCmd(t)
+	if len(q) != 0 {
+		t.Errorf("plain `tdns list` should send no query params, got %v", q)
+	}
+}
+
+func TestListCmdSendsFilterAndPaginationParams(t *testing.T) {
+	q := runListCmd(t, "--name", "ex*", "--type", "primary", "--page", "2", "--per-page", "5")
+	for k, want := range map[string]string{
+		"filterName":   "ex*",
+		"filterType":   "Primary", // canonicalized from "primary"
+		"pageNumber":   "2",
+		"zonesPerPage": "5",
+	} {
+		if got := q[k]; len(got) != 1 || got[0] != want {
+			t.Errorf("query %s = %v, want %q", k, got, want)
+		}
+	}
+}


### PR DESCRIPTION
* Add --name/-n and --type/-y flags mapping to the filterName/filterType parameters added to /api/zones/list in Technitium DNS Server v15.3, plus --page/--per-page for the endpoint's pagination.

* For backwards compatibility the same filter is also applied client-side, so filtering works against pre-15.3 servers that ignore the parameters (idempotent on newer servers). A plain 'tdns list' sends the exact same request as before.

* Also replace the panic-prone bare type assertions in the zone renderer with tolerant reads, and surface isExpired/syncFailed/notifyFailed and the pagination summary when the server provides them.