### PR TITLE
feat(import): add overwrite-zone, overwrite and create flags 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also use:
 
 ```bash
 tdns list [--name 'example.*'] [--type Primary] [--page 1 --per-page 10] [--json]
-tdns import <zone> --file zone.txt [--overwrite-zone] [--create] [--json]
+tdns import <zone> --file zone.txt|- [--overwrite-zone] [--create] [--json]
 tdns export <zone> [--output-dir dir] [--json]
 tdns create <zone>... [--type Primary]
 tdns delete <zone>...
@@ -63,6 +63,16 @@ tdns delete <zone>...
 Forwarder zone. Add `--create` to create the zone first if it isn't there yet
 (`--type Forwarder` to create a Forwarder zone instead of a Primary one); it's a
 no-op when the zone already exists, so it's safe to leave on in automation.
+
+`--file` (`-f`) is required, and `--file -` reads the zone from standard input,
+so a generated zone file needs no temporary file:
+
+```bash
+generate-zone example.com | tdns import example.com --file -
+```
+
+Empty input is rejected rather than posted, since an empty import combined with
+`--overwrite-zone` would clear the zone and put nothing back.
 
 Import behaviour is controlled by three flags mapping to the API parameters:
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,54 @@ You can also use:
 
 ```bash
 tdns list [--name 'example.*'] [--type Primary] [--page 1 --per-page 10] [--json]
-tdns import <zone> --file zone.txt [--json]
+tdns import <zone> --file zone.txt [--overwrite-zone] [--create] [--json]
 tdns export <zone> [--output-dir dir] [--json]
 tdns create <zone>... [--type Primary]
 tdns delete <zone>...
 ```
+
+#### Importing zones
+
+`tdns import` posts an RFC 1035 (BIND style) zone file to an existing Primary or
+Forwarder zone. Add `--create` to create the zone first if it isn't there yet
+(`--type Forwarder` to create a Forwarder zone instead of a Primary one); it's a
+no-op when the zone already exists, so it's safe to leave on in automation.
+
+Import behaviour is controlled by three flags mapping to the API parameters:
+
+| Flag | Default | Effect |
+| --- | --- | --- |
+| `--overwrite` | `true` | Overwrite existing record sets for the records being imported |
+| `--overwrite-zone` | `false` | Delete **all** existing records in the zone first, so only the imported ones remain (needs Technitium v15.0+) |
+| `--overwrite-soa-serial` | `true` | Use the SOA serial from the file instead of bumping the current one |
+
+So a full replace from a generated zone file is:
+
+```bash
+tdns import example.com --file example.com.zone --create --overwrite-zone --yes
+```
+
+> [!WARNING]
+`--overwrite-zone` also deletes the zone's apex `NS` records, so your zone file
+must contain them or the zone will be left with none. The zone's `SOA` record is
+kept (and is optional in the file), and DNSSEC records are always managed by the
+server — it ignores `DNSKEY`/`RRSIG`/`NSEC`/`NSEC3`/`NSEC3PARAM` on import and
+keeps the existing ones. `tdns export` output is safe to feed straight back in.
+You'll be asked to confirm unless you pass `--yes` (`-y`).
+
+> [!NOTE]
+Because servers older than v15.0 silently ignore unknown parameters — and would
+therefore import *without* clearing the zone — `--overwrite-zone` checks the
+server version first and refuses to run against an older server. If the version
+can't be read (for example when the API token has no permission to read
+settings) you get a warning and the import proceeds.
+
+> [!NOTE]
+`--overwrite-soa-serial` defaults to `true` to match earlier `tdns` releases,
+which differs from the API's own default of `false`. Importing a file whose
+serial is *lower* than the zone's current serial will make secondary zones fail
+to sync — pass `--overwrite-soa-serial=false` to let the server bump the serial
+itself instead.
 
 ### Records
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -20,6 +22,36 @@ var validZoneTypes = map[string]bool{
 	"SecondaryForwarder": true,
 	"Catalog":            true,
 	"SecondaryCatalog":   true,
+}
+
+// createZone calls /api/zones/create and returns the domain name reported by
+// the server. It is shared by the `create` command and `import --create`.
+func createZone(client *api.Client, zone, zoneType string, useSoaSerialDateScheme bool, primaryNameServerAddresses string) (string, error) {
+	q := url.Values{
+		"zone":                   {zone},
+		"type":                   {zoneType},
+		"useSoaSerialDateScheme": {strconv.FormatBool(useSoaSerialDateScheme)},
+	}
+	if primaryNameServerAddresses != "" {
+		q.Set("primaryNameServerAddresses", primaryNameServerAddresses)
+	}
+
+	_, response, err := client.GetJSON("/api/zones/create", q)
+	if err != nil {
+		return "", err
+	}
+	domain, _ := response["domain"].(string)
+	return domain, nil
+}
+
+// isZoneExistsError reports whether err is the API's "Zone already exists"
+// rejection, which `import --create` treats as success.
+func isZoneExistsError(err error) bool {
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return strings.Contains(strings.ToLower(apiErr.Message), "zone already exists")
 }
 
 var createCmd = &cobra.Command{
@@ -43,28 +75,19 @@ var createCmd = &cobra.Command{
 
 		client := api.New()
 		for _, zone := range args {
-			q := url.Values{
-				"zone":                   {zone},
-				"type":                   {zoneType},
-				"useSoaSerialDateScheme": {strconv.FormatBool(useSerial)},
-			}
-			if nameServers != "" {
-				q.Set("primaryNameServerAddresses", nameServers)
-			}
-
-			_, response, err := client.GetJSON("/api/zones/create", q)
+			domain, err := createZone(client, zone, zoneType, useSerial, nameServers)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "❌ Failed to create zone %s: %v\n", zone, err)
 				os.Exit(1)
 			}
-			fmt.Printf("✅ Zone %v created successfully.\n", response["domain"])
+			fmt.Printf("✅ Zone %v created successfully.\n", domain)
 		}
 	},
 }
 
 func init() {
 	createCmd.Flags().StringP("type", "y", "Primary", "Zone type")
-	createCmd.Flags().String("useSoaSerialDateScheme", "true", "Use date-based SOA serial scheme (true|false)")
+	createCmd.Flags().Bool("useSoaSerialDateScheme", true, "Use date-based SOA serial scheme")
 	createCmd.Flags().String("primaryNameServerAddresses", "", "Comma-separated list of primary name server IPs")
 	rootCmd.AddCommand(createCmd)
 }

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// runCreateCmd executes `tdns create <args>` against a stub server and returns
+// the query values the server received.
+func runCreateCmd(t *testing.T, args ...string) map[string][]string {
+	t.Helper()
+
+	var gotQuery map[string][]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"ok","response":{"domain":"example.com"}}`)
+	}))
+	defer srv.Close()
+
+	oldHost := viper.GetString("host")
+	viper.Set("host", srv.URL)
+	defer viper.Set("host", oldHost)
+
+	oldStdout := os.Stdout
+	rp, wp, _ := os.Pipe()
+	os.Stdout = wp
+	defer func() { os.Stdout = oldStdout }()
+	go func() { _, _ = io.Copy(io.Discard, rp) }()
+
+	rootCmd.SetArgs(append([]string{"create"}, args...))
+	defer rootCmd.SetArgs(nil)
+	// Flags persist across Execute calls; restore the declared default.
+	defer func() { _ = createCmd.Flags().Set("useSoaSerialDateScheme", "true") }()
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("create command failed: %v", err)
+	}
+	wp.Close()
+
+	return gotQuery
+}
+
+// useSoaSerialDateScheme was declared as a string flag but read with GetBool,
+// so it always resolved to false regardless of what the user passed.
+func TestCreateCmdUseSoaSerialDateScheme(t *testing.T) {
+	if got := runCreateCmd(t, "example.com")["useSoaSerialDateScheme"]; len(got) != 1 || got[0] != "true" {
+		t.Errorf("default useSoaSerialDateScheme = %v, want true", got)
+	}
+	if got := runCreateCmd(t, "example.com", "--useSoaSerialDateScheme=false")["useSoaSerialDateScheme"]; len(got) != 1 || got[0] != "false" {
+		t.Errorf("useSoaSerialDateScheme=false = %v, want false", got)
+	}
+	if got := runCreateCmd(t, "example.com", "--useSoaSerialDateScheme=true")["useSoaSerialDateScheme"]; len(got) != 1 || got[0] != "true" {
+		t.Errorf("useSoaSerialDateScheme=true = %v, want true", got)
+	}
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"strconv"
@@ -56,6 +57,35 @@ func checkOverwriteZoneSupported(client *api.Client) {
 	}
 }
 
+// readZoneFile reads the zone file at path, or standard input when path is
+// "-". Empty input is rejected: posting nothing would silently succeed, and
+// combined with --overwrite-zone it would clear the zone and put nothing back.
+func readZoneFile(path string) ([]byte, error) {
+	var (
+		data []byte
+		err  error
+	)
+	if path == "-" {
+		data, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read zone file from stdin: %w", err)
+		}
+	} else {
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read zone file: %w", err)
+		}
+	}
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		if path == "-" {
+			return nil, fmt.Errorf("no zone data received on stdin")
+		}
+		return nil, fmt.Errorf("zone file %s is empty", path)
+	}
+	return data, nil
+}
+
 // buildImportQuery maps the import flags onto /api/zones/import query
 // parameters. `overwriteZone` is only sent when enabled so that the request
 // stays identical to previous releases against servers older than v15.0.
@@ -77,6 +107,11 @@ var importCmd = &cobra.Command{
 	Short:   "Import a DNS zone",
 	Long: `Import records from an RFC 1035 (BIND style) zone file into an existing zone.
 
+The zone file is named with --file, or read from standard input when --file is
+"-", so a generated zone file can be piped straight in:
+
+  generate-zone example.com | tdns import example.com --file -
+
 The zone must already exist and be of type Primary or Forwarder; pass --create
 to create it first.
 
@@ -95,9 +130,9 @@ NSEC3PARAM), which the server always manages itself and ignores on import.`,
 			os.Exit(1)
 		}
 
-		data, err := os.ReadFile(importFile)
+		data, err := readZoneFile(importFile)
 		if err != nil {
-			fmt.Printf("Failed to read file: %v\n", err)
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
 		}
 
@@ -165,7 +200,10 @@ NSEC3PARAM), which the server always manages itself and ignores on import.`,
 }
 
 func init() {
-	importCmd.Flags().StringVarP(&importFile, "file", "f", "data.txt", "Zone file to import")
+	importCmd.Flags().StringVarP(&importFile, "file", "f", "", "Zone file to import, or - to read it from stdin (required)")
+	if err := importCmd.MarkFlagRequired("file"); err != nil {
+		panic(err)
+	}
 	importCmd.Flags().BoolVar(&importJSON, "json", false, "Print raw JSON response")
 	importCmd.Flags().BoolVar(&importOverwrite, "overwrite", true, "Overwrite existing record sets for the records being imported")
 	importCmd.Flags().BoolVar(&importOverwriteZone, "overwrite-zone", false, "Delete all existing records in the zone before importing (Technitium v15.0+)")

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -6,22 +6,94 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"tdns/internal/api"
 )
 
-var importFile string
-var importJSON bool
+var (
+	importFile string
+	importJSON bool
+
+	// import options mapped onto /api/zones/import query parameters
+	importOverwrite          bool
+	importOverwriteZone      bool
+	importOverwriteSoaSerial bool
+
+	// create the zone before importing into it
+	importCreate     bool
+	importCreateType string
+)
+
+// importableZoneTypes are the zone types the server accepts records for via
+// /api/zones/import, so the only types --create may produce.
+var importableZoneTypes = map[string]bool{
+	"Primary":   true,
+	"Forwarder": true,
+}
+
+// minOverwriteZoneVersion is the first server release that understands the
+// `overwriteZone` parameter. Older servers ignore unknown parameters, so
+// without this check the import would silently not overwrite the zone.
+const minOverwriteZoneVersion = "15.0"
+
+// checkOverwriteZoneSupported exits when the server is too old to honor
+// `overwriteZone`. A server that won't report its version (for example when
+// the token lacks permission to read settings) only produces a warning, since
+// refusing the import outright would be worse than the silent no-op we are
+// trying to prevent.
+func checkOverwriteZoneSupported(client *api.Client) {
+	ok, version, err := client.ServerAtLeast(minOverwriteZoneVersion)
+	switch {
+	case err != nil:
+		fmt.Fprintf(os.Stderr, "⚠️  Could not verify that the server supports --overwrite-zone (needs v%s+): %v\n", minOverwriteZoneVersion, err)
+	case !ok:
+		fmt.Fprintf(os.Stderr, "❌ --overwrite-zone requires Technitium DNS Server v%s or later, but the server reports v%s.\n", minOverwriteZoneVersion, version)
+		fmt.Fprintln(os.Stderr, "Older servers ignore the option and would import without clearing the zone.")
+		os.Exit(1)
+	}
+}
+
+// buildImportQuery maps the import flags onto /api/zones/import query
+// parameters. `overwriteZone` is only sent when enabled so that the request
+// stays identical to previous releases against servers older than v15.0.
+func buildImportQuery(zone string, overwrite, overwriteZone, overwriteSoaSerial bool) url.Values {
+	q := url.Values{
+		"zone":               {zone},
+		"overwrite":          {strconv.FormatBool(overwrite)},
+		"overwriteSoaSerial": {strconv.FormatBool(overwriteSoaSerial)},
+	}
+	if overwriteZone {
+		q.Set("overwriteZone", "true")
+	}
+	return q
+}
 
 var importCmd = &cobra.Command{
 	Use:     "import [zone]",
 	Aliases: []string{"im"},
 	Short:   "Import a DNS zone",
-	Args:    cobra.ExactArgs(1),
+	Long: `Import records from an RFC 1035 (BIND style) zone file into an existing zone.
+
+The zone must already exist and be of type Primary or Forwarder; pass --create
+to create it first.
+
+With --overwrite-zone (Technitium v15.0+) every existing record in the zone is
+deleted before the import, so only the imported records remain. Note that this
+includes the zone's apex NS records, so the zone file must contain them. The
+zone's SOA record is kept, as are DNSSEC records (DNSKEY/RRSIG/NSEC/NSEC3/
+NSEC3PARAM), which the server always manages itself and ignores on import.`,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		zone := args[0]
+
+		if importCreate && !importableZoneTypes[importCreateType] {
+			fmt.Fprintf(os.Stderr, "❌ Invalid zone type: %s\n", importCreateType)
+			fmt.Fprintln(os.Stderr, "Only Primary and Forwarder zones can be imported into.")
+			os.Exit(1)
+		}
 
 		data, err := os.ReadFile(importFile)
 		if err != nil {
@@ -29,12 +101,42 @@ var importCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		q := url.Values{
-			"zone":               {zone},
-			"overwrite":          {"true"},
-			"overwriteSoaSerial": {"true"},
+		client := api.New()
+
+		if importOverwriteZone {
+			// Verify support before prompting, so the user isn't asked to
+			// confirm something the server would silently ignore.
+			checkOverwriteZoneSupported(client)
+
+			if !assumeYes {
+				fmt.Printf("This deletes all existing records in zone '%s' before importing. Are you sure? (yes/no): ", zone)
+				var confirm string
+				fmt.Scanln(&confirm)
+				if confirm != "yes" {
+					fmt.Println("❌ Aborted.")
+					return
+				}
+			}
 		}
-		resp, err := api.New().Post("/api/zones/import", q, bytes.NewReader(data), "text/plain")
+
+		if importCreate {
+			// The zone file supplies the SOA serial, so leave the server's
+			// date-based serial scheme off.
+			if _, err := createZone(client, zone, importCreateType, false, ""); err != nil {
+				if !isZoneExistsError(err) {
+					fmt.Fprintf(os.Stderr, "❌ Failed to create zone %s: %v\n", zone, err)
+					os.Exit(1)
+				}
+				if !importJSON {
+					fmt.Printf("ℹ️  Zone '%s' already exists, importing into it.\n", zone)
+				}
+			} else if !importJSON {
+				fmt.Printf("✅ Zone '%s' created successfully.\n", zone)
+			}
+		}
+
+		q := buildImportQuery(zone, importOverwrite, importOverwriteZone, importOverwriteSoaSerial)
+		resp, err := client.Post("/api/zones/import", q, bytes.NewReader(data), "text/plain")
 		if err != nil {
 			fmt.Printf("Request failed: %v\n", err)
 			os.Exit(1)
@@ -65,5 +167,11 @@ var importCmd = &cobra.Command{
 func init() {
 	importCmd.Flags().StringVarP(&importFile, "file", "f", "data.txt", "Zone file to import")
 	importCmd.Flags().BoolVar(&importJSON, "json", false, "Print raw JSON response")
+	importCmd.Flags().BoolVar(&importOverwrite, "overwrite", true, "Overwrite existing record sets for the records being imported")
+	importCmd.Flags().BoolVar(&importOverwriteZone, "overwrite-zone", false, "Delete all existing records in the zone before importing (Technitium v15.0+)")
+	importCmd.Flags().BoolVar(&importOverwriteSoaSerial, "overwrite-soa-serial", true, "Take the SOA serial from the imported file. Warning: a serial lower than the current one makes secondary zones fail to sync")
+	importCmd.Flags().BoolVar(&importCreate, "create", false, "Create the zone first if it does not exist")
+	importCmd.Flags().StringVar(&importCreateType, "type", "Primary", "Zone type to use with --create (Primary or Forwarder)")
+	importCmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "Assume yes when asking for confirmation")
 	rootCmd.AddCommand(importCmd)
 }

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -1,0 +1,284 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	"tdns/internal/api"
+)
+
+func TestBuildImportQuery(t *testing.T) {
+	// Defaults must keep sending the parameters previous releases sent, and
+	// must not mention overwriteZone at all.
+	q := buildImportQuery("example.com", true, false, true)
+	for k, want := range map[string]string{
+		"zone":               "example.com",
+		"overwrite":          "true",
+		"overwriteSoaSerial": "true",
+	} {
+		if got := q.Get(k); got != want {
+			t.Errorf("query %s = %q, want %q", k, got, want)
+		}
+	}
+	if _, ok := q["overwriteZone"]; ok {
+		t.Errorf("overwriteZone should be omitted when disabled, got %v", q)
+	}
+
+	q = buildImportQuery("example.com", false, true, false)
+	for k, want := range map[string]string{
+		"overwrite":          "false",
+		"overwriteZone":      "true",
+		"overwriteSoaSerial": "false",
+	} {
+		if got := q.Get(k); got != want {
+			t.Errorf("query %s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestIsZoneExistsError(t *testing.T) {
+	if !isZoneExistsError(&api.APIError{Message: "Zone already exists: example.com"}) {
+		t.Error("should match the API's zone-exists rejection")
+	}
+	if !isZoneExistsError(fmt.Errorf("wrapped: %w", &api.APIError{Message: "Zone already exists: example.com"})) {
+		t.Error("should match through a wrapped error")
+	}
+	if isZoneExistsError(&api.APIError{Message: "Access was denied."}) {
+		t.Error("should not match unrelated API errors")
+	}
+	if isZoneExistsError(errors.New("Zone already exists: example.com")) {
+		t.Error("should only match *api.APIError, not any error mentioning it")
+	}
+	if isZoneExistsError(nil) {
+		t.Error("nil is not a zone-exists error")
+	}
+}
+
+// importRequest records what the stub server received for one API call.
+type importRequest struct {
+	path  string
+	query map[string][]string
+	body  string
+}
+
+// runImportCmd executes `tdns import <args>` against a stub server and returns
+// the requests it received, in order.
+func runImportCmd(t *testing.T, handler func(r *http.Request) string, args ...string) []importRequest {
+	t.Helper()
+
+	var got []importRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		got = append(got, importRequest{
+			path:  r.URL.Path,
+			query: r.URL.Query(),
+			body:  string(body),
+		})
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, handler(r))
+	}))
+	defer srv.Close()
+
+	oldHost := viper.GetString("host")
+	viper.Set("host", srv.URL)
+	defer viper.Set("host", oldHost)
+
+	// Reset flag-bound package vars from any previous invocation.
+	importJSON = false
+	importOverwrite = true
+	importOverwriteZone = false
+	importOverwriteSoaSerial = true
+	importCreate = false
+	importCreateType = "Primary"
+	assumeYes = false
+
+	// Silence the command's stdout while it runs.
+	oldStdout := os.Stdout
+	rp, wp, _ := os.Pipe()
+	os.Stdout = wp
+	defer func() { os.Stdout = oldStdout }()
+	go func() { _, _ = io.Copy(io.Discard, rp) }()
+
+	rootCmd.SetArgs(append([]string{"import"}, args...))
+	defer rootCmd.SetArgs(nil)
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("import command failed: %v", err)
+	}
+	wp.Close()
+
+	return got
+}
+
+// writeZoneFile creates a throwaway zone file and returns its path.
+func writeZoneFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "zone.txt")
+	contents := "example.com. 3600 IN NS ns1.example.com.\n"
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("write zone file: %v", err)
+	}
+	return path
+}
+
+// okResponse answers every call with success, reporting a server version new
+// enough for --overwrite-zone.
+func okResponse(r *http.Request) string {
+	if strings.HasSuffix(r.URL.Path, "/api/settings/get") {
+		return `{"status":"ok","response":{"version":"15.0.1"}}`
+	}
+	return `{"status":"ok","response":{}}`
+}
+
+func TestImportCmdDefaultsMatchPreviousBehaviour(t *testing.T) {
+	reqs := runImportCmd(t, okResponse, "example.com", "--file", writeZoneFile(t))
+	if len(reqs) != 1 {
+		t.Fatalf("got %d requests, want 1: %v", len(reqs), reqs)
+	}
+	if reqs[0].path != "/api/zones/import" {
+		t.Errorf("path = %q, want /api/zones/import", reqs[0].path)
+	}
+	for k, want := range map[string]string{
+		"zone":               "example.com",
+		"overwrite":          "true",
+		"overwriteSoaSerial": "true",
+	} {
+		if got := reqs[0].query[k]; len(got) != 1 || got[0] != want {
+			t.Errorf("query %s = %v, want %q", k, got, want)
+		}
+	}
+	if _, ok := reqs[0].query["overwriteZone"]; ok {
+		t.Error("overwriteZone must not be sent by default")
+	}
+	if !strings.Contains(reqs[0].body, "ns1.example.com") {
+		t.Errorf("zone file was not posted as the body: %q", reqs[0].body)
+	}
+}
+
+// findRequest returns the first recorded request for path.
+func findRequest(t *testing.T, reqs []importRequest, path string) importRequest {
+	t.Helper()
+	for _, r := range reqs {
+		if r.path == path {
+			return r
+		}
+	}
+	t.Fatalf("no request to %s, got %v", path, reqs)
+	return importRequest{}
+}
+
+func TestImportCmdOverwriteZone(t *testing.T) {
+	reqs := runImportCmd(t, okResponse,
+		"example.com", "--file", writeZoneFile(t), "--overwrite-zone", "--yes")
+
+	// The version gate must run before the destructive import.
+	if len(reqs) != 2 || reqs[0].path != "/api/settings/get" {
+		t.Fatalf("want a version check followed by the import, got %v", reqs)
+	}
+	imp := findRequest(t, reqs, "/api/zones/import")
+	if got := imp.query["overwriteZone"]; len(got) != 1 || got[0] != "true" {
+		t.Errorf("overwriteZone = %v, want true", got)
+	}
+}
+
+func TestImportCmdSkipsVersionCheckWithoutOverwriteZone(t *testing.T) {
+	reqs := runImportCmd(t, okResponse, "example.com", "--file", writeZoneFile(t))
+	for _, r := range reqs {
+		if r.path == "/api/settings/get" {
+			t.Error("version check should only run for --overwrite-zone")
+		}
+	}
+}
+
+func TestImportCmdProceedsWhenVersionUnavailable(t *testing.T) {
+	// A token that cannot read settings must not block the import; the command
+	// warns and carries on rather than refusing outright.
+	handler := func(r *http.Request) string {
+		if strings.HasSuffix(r.URL.Path, "/api/settings/get") {
+			return `{"status":"error","errorMessage":"Access was denied."}`
+		}
+		return `{"status":"ok","response":{}}`
+	}
+	reqs := runImportCmd(t, handler,
+		"example.com", "--file", writeZoneFile(t), "--overwrite-zone", "--yes")
+	imp := findRequest(t, reqs, "/api/zones/import")
+	if got := imp.query["overwriteZone"]; len(got) != 1 || got[0] != "true" {
+		t.Errorf("overwriteZone = %v, want true", got)
+	}
+}
+
+func TestImportCmdOverwriteFlagsCanBeDisabled(t *testing.T) {
+	reqs := runImportCmd(t, okResponse, "example.com", "--file", writeZoneFile(t),
+		"--overwrite=false", "--overwrite-soa-serial=false")
+	if len(reqs) != 1 {
+		t.Fatalf("got %d requests, want 1: %v", len(reqs), reqs)
+	}
+	for k, want := range map[string]string{
+		"overwrite":          "false",
+		"overwriteSoaSerial": "false",
+	} {
+		if got := reqs[0].query[k]; len(got) != 1 || got[0] != want {
+			t.Errorf("query %s = %v, want %q", k, got, want)
+		}
+	}
+}
+
+func TestImportCmdCreateCreatesZoneFirst(t *testing.T) {
+	reqs := runImportCmd(t, okResponse,
+		"example.com", "--file", writeZoneFile(t), "--create")
+	if len(reqs) != 2 {
+		t.Fatalf("got %d requests, want 2 (create then import): %v", len(reqs), reqs)
+	}
+	if reqs[0].path != "/api/zones/create" {
+		t.Errorf("first call = %q, want /api/zones/create", reqs[0].path)
+	}
+	for k, want := range map[string]string{
+		"zone":                   "example.com",
+		"type":                   "Primary",
+		"useSoaSerialDateScheme": "false",
+	} {
+		if got := reqs[0].query[k]; len(got) != 1 || got[0] != want {
+			t.Errorf("create query %s = %v, want %q", k, got, want)
+		}
+	}
+	if reqs[1].path != "/api/zones/import" {
+		t.Errorf("second call = %q, want /api/zones/import", reqs[1].path)
+	}
+}
+
+func TestImportCmdCreateIsIdempotent(t *testing.T) {
+	// An existing zone must not abort the import.
+	handler := func(r *http.Request) string {
+		if strings.HasSuffix(r.URL.Path, "/create") {
+			return `{"status":"error","errorMessage":"Zone already exists: example.com"}`
+		}
+		return `{"status":"ok","response":{}}`
+	}
+	reqs := runImportCmd(t, handler,
+		"example.com", "--file", writeZoneFile(t), "--create")
+	if len(reqs) != 2 {
+		t.Fatalf("got %d requests, want 2: %v", len(reqs), reqs)
+	}
+	if reqs[1].path != "/api/zones/import" {
+		t.Errorf("import must still run after a zone-exists error, got %q", reqs[1].path)
+	}
+}
+
+func TestImportCmdCreateForwarderType(t *testing.T) {
+	reqs := runImportCmd(t, okResponse,
+		"example.com", "--file", writeZoneFile(t), "--create", "--type", "Forwarder")
+	if len(reqs) != 2 {
+		t.Fatalf("got %d requests, want 2: %v", len(reqs), reqs)
+	}
+	if got := reqs[0].query["type"]; len(got) != 1 || got[0] != "Forwarder" {
+		t.Errorf("create type = %v, want Forwarder", got)
+	}
+}

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -74,6 +74,17 @@ type importRequest struct {
 // the requests it received, in order.
 func runImportCmd(t *testing.T, handler func(r *http.Request) string, args ...string) []importRequest {
 	t.Helper()
+	reqs, err := execImportCmd(t, handler, args...)
+	if err != nil {
+		t.Fatalf("import command failed: %v", err)
+	}
+	return reqs
+}
+
+// execImportCmd is runImportCmd without the assertion, for cases that expect
+// the command to reject its arguments.
+func execImportCmd(t *testing.T, handler func(r *http.Request) string, args ...string) ([]importRequest, error) {
+	t.Helper()
 
 	var got []importRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -92,7 +103,11 @@ func runImportCmd(t *testing.T, handler func(r *http.Request) string, args ...st
 	viper.Set("host", srv.URL)
 	defer viper.Set("host", oldHost)
 
-	// Reset flag-bound package vars from any previous invocation.
+	// Reset flag-bound package vars from any previous invocation. --file is a
+	// required flag, and cobra decides that from Changed, which persists across
+	// Execute calls; clear it so tests cannot mask a missing default.
+	importCmd.Flags().Lookup("file").Changed = false
+	importFile = ""
 	importJSON = false
 	importOverwrite = true
 	importOverwriteZone = false
@@ -110,23 +125,99 @@ func runImportCmd(t *testing.T, handler func(r *http.Request) string, args ...st
 
 	rootCmd.SetArgs(append([]string{"import"}, args...))
 	defer rootCmd.SetArgs(nil)
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("import command failed: %v", err)
-	}
+	err := rootCmd.Execute()
 	wp.Close()
 
-	return got
+	return got, err
 }
+
+const testZoneContents = "example.com. 3600 IN NS ns1.example.com.\n"
 
 // writeZoneFile creates a throwaway zone file and returns its path.
 func writeZoneFile(t *testing.T) string {
+	return writeTempFile(t, testZoneContents)
+}
+
+func writeTempFile(t *testing.T, contents string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "zone.txt")
-	contents := "example.com. 3600 IN NS ns1.example.com.\n"
 	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
 		t.Fatalf("write zone file: %v", err)
 	}
 	return path
+}
+
+func TestReadZoneFile(t *testing.T) {
+	data, err := readZoneFile(writeZoneFile(t))
+	if err != nil {
+		t.Fatalf("readZoneFile: %v", err)
+	}
+	if string(data) != testZoneContents {
+		t.Errorf("contents = %q, want %q", data, testZoneContents)
+	}
+
+	if _, err := readZoneFile(filepath.Join(t.TempDir(), "missing.txt")); err == nil {
+		t.Error("a missing file should error")
+	}
+
+	// Empty input must be refused rather than posted: with --overwrite-zone it
+	// would clear the zone and import nothing.
+	if _, err := readZoneFile(writeTempFile(t, "   \n\t\n")); err == nil {
+		t.Error("an empty file should error")
+	}
+}
+
+// withStdin points os.Stdin at a file holding contents for the duration of the
+// test.
+func withStdin(t *testing.T, contents string) {
+	t.Helper()
+	f, err := os.Open(writeTempFile(t, contents))
+	if err != nil {
+		t.Fatalf("open stdin stub: %v", err)
+	}
+	old := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() {
+		os.Stdin = old
+		f.Close()
+	})
+}
+
+func TestReadZoneFileFromStdin(t *testing.T) {
+	withStdin(t, testZoneContents)
+	data, err := readZoneFile("-")
+	if err != nil {
+		t.Fatalf("readZoneFile(\"-\"): %v", err)
+	}
+	if string(data) != testZoneContents {
+		t.Errorf("contents = %q, want %q", data, testZoneContents)
+	}
+}
+
+func TestReadZoneFileFromEmptyStdin(t *testing.T) {
+	withStdin(t, "")
+	if _, err := readZoneFile("-"); err == nil {
+		t.Error("empty stdin should error")
+	}
+}
+
+func TestImportCmdRequiresFile(t *testing.T) {
+	_, err := execImportCmd(t, okResponse, "example.com")
+	if err == nil {
+		t.Fatal("import without --file should fail")
+	}
+	if !strings.Contains(err.Error(), "file") {
+		t.Errorf("error should name the missing flag, got %v", err)
+	}
+}
+
+func TestImportCmdReadsStdin(t *testing.T) {
+	withStdin(t, testZoneContents)
+	reqs := runImportCmd(t, okResponse, "example.com", "--file", "-")
+	imp := findRequest(t, reqs, "/api/zones/import")
+	if imp.body != testZoneContents {
+		t.Errorf("body = %q, want the piped zone file %q", imp.body, testZoneContents)
+	}
 }
 
 // okResponse answers every call with success, reporting a server version new

--- a/internal/api/version.go
+++ b/internal/api/version.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// parseVersion splits a dot-separated version string such as "15.0.1" into its
+// numeric components. An optional leading "v" is ignored, and parsing stops at
+// the first component that does not begin with a digit, so suffixed versions
+// like "15.0-beta" parse as [15, 0].
+func parseVersion(s string) ([]int, error) {
+	s = strings.TrimSpace(s)
+	if len(s) > 0 && (s[0] == 'v' || s[0] == 'V') {
+		s = s[1:]
+	}
+
+	var parts []int
+	for _, field := range strings.Split(s, ".") {
+		end := 0
+		for end < len(field) && field[end] >= '0' && field[end] <= '9' {
+			end++
+		}
+		if end == 0 {
+			break
+		}
+		n, err := strconv.Atoi(field[:end])
+		if err != nil {
+			break
+		}
+		parts = append(parts, n)
+	}
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("unrecognized version string %q", s)
+	}
+	return parts, nil
+}
+
+// CompareVersions returns -1 if a < b, 0 if they are equal, and 1 if a > b.
+// Missing trailing components count as zero, so "15.0" equals "15.0.0".
+func CompareVersions(a, b string) (int, error) {
+	av, err := parseVersion(a)
+	if err != nil {
+		return 0, err
+	}
+	bv, err := parseVersion(b)
+	if err != nil {
+		return 0, err
+	}
+	for i := 0; i < len(av) || i < len(bv); i++ {
+		var x, y int
+		if i < len(av) {
+			x = av[i]
+		}
+		if i < len(bv) {
+			y = bv[i]
+		}
+		if x != y {
+			if x < y {
+				return -1, nil
+			}
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+// ServerAtLeast reports whether the connected server's version is at least
+// min. It also returns the version the server reported, for error messages.
+func (c *Client) ServerAtLeast(min string) (bool, string, error) {
+	version, err := c.ServerVersion()
+	if err != nil {
+		return false, "", err
+	}
+	cmp, err := CompareVersions(version, min)
+	if err != nil {
+		return false, version, err
+	}
+	return cmp >= 0, version, nil
+}

--- a/internal/api/version_test.go
+++ b/internal/api/version_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"15.0", "15.0", 0},
+		{"15.0", "15.0.0", 0}, // missing components count as zero
+		{"15.0.1", "15.0", 1},
+		{"14.9.9", "15.0", -1},
+		{"15.1", "15.0", 1},
+		{"9.0", "15.0", -1}, // numeric, not lexicographic
+		{"15.0.1.2", "15.0.1", 1},
+		{"15.0-beta", "15.0", 0}, // suffixes are ignored
+		{"v15.0", "15.0", 0},     // a leading "v" is tolerated
+	}
+	for _, tt := range tests {
+		got, err := CompareVersions(tt.a, tt.b)
+		if err != nil {
+			t.Errorf("CompareVersions(%q, %q): %v", tt.a, tt.b, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+
+	if _, err := CompareVersions("", "15.0"); err == nil {
+		t.Error("empty version should error")
+	}
+	if _, err := CompareVersions("unknown", "15.0"); err == nil {
+		t.Error("non-numeric version should error")
+	}
+}
+
+func TestServerAtLeast(t *testing.T) {
+	serve := func(body string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+		}))
+	}
+
+	srv := serve(`{"status":"ok","response":{"version":"15.0.1"}}`)
+	defer srv.Close()
+	ok, version, err := (&Client{Host: srv.URL, HTTP: srv.Client()}).ServerAtLeast("15.0")
+	if err != nil || !ok || version != "15.0.1" {
+		t.Errorf("ServerAtLeast = %v, %q, %v; want true, \"15.0.1\", nil", ok, version, err)
+	}
+
+	old := serve(`{"status":"ok","response":{"version":"14.1"}}`)
+	defer old.Close()
+	ok, version, err = (&Client{Host: old.URL, HTTP: old.Client()}).ServerAtLeast("15.0")
+	if err != nil || ok || version != "14.1" {
+		t.Errorf("ServerAtLeast = %v, %q, %v; want false, \"14.1\", nil", ok, version, err)
+	}
+
+	denied := serve(`{"status":"error","errorMessage":"Access was denied."}`)
+	defer denied.Close()
+	if ok, _, err = (&Client{Host: denied.URL, HTTP: denied.Client()}).ServerAtLeast("15.0"); err == nil || ok {
+		t.Errorf("ServerAtLeast on an error response = %v, %v; want false and an error", ok, err)
+	}
+}


### PR DESCRIPTION
Surface Technitium v15.0's `overwriteZone` import option, which deletes
every existing record in the zone before importing so that only the
imported records remain. This removes the need to manually delete records
before re-importing a generated BIND style zone file.

The previously hardcoded `overwrite` and `overwriteSoaSerial` parameters
become flags too, keeping their current values as defaults so existing
invocations behave identically. Because `--overwrite-zone` is destructive
it prompts for confirmation unless `-y`/`--yes` is passed, and it is only
sent to the API when enabled, leaving requests unchanged for everyone who
doesn't use it.

Servers older than v15.0 ignore unknown query parameters, so passing
`overwriteZone` to one would import the records without clearing the zone
first and still report success — the exact manual cleanup the option exists
to avoid, silently skipped. Check the version reported by /api/settings/get
before such an import and refuse to run against an older server. The extra
round-trip only happens when the option is used, and a server that will not
report its version at all, such as when the API token lacks permission to
read settings, only produces a warning.

Add `--create` (with `--type`) to create the zone before importing, since
the API requires the zone to already exist. It reuses the `create` command's
code path via a new shared `createZone` helper and treats the API's "Zone
already exists" rejection as success, so it is safe to leave enabled in
automation.

Fix `create`'s `useSoaSerialDateScheme` flag along the way: it was declared
with Flags().String but read back with GetBool, which always failed and
yielded false, so the flag sent the opposite of what was asked and its
documented default of true never took effect. It is now a bool flag, which
means `--useSoaSerialDateScheme=false` rather than a space-separated value,
and zones created without an explicit value use the date-based serial scheme
the help text always advertised.

Drop default input file and make it a required parameter!

Fixes https://github.com/mbevc1/tdns/issues/72