### PR TITLE
fix(list): warn when filtering paginated results needs a newer server

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ tdns create <zone>... [--type Primary]
 tdns delete <zone>...
 ```
 
+> [!NOTE]
+`tdns list --name`/`--type` work against any server: v15.3+ filter server-side,
+and on older servers the same filter is applied locally. Combining a filter with
+`--page`/`--per-page` needs v15.3+ to be accurate though, because filtering an
+older server's response locally can only consider the page it returned — matches
+on other pages aren't shown, and the page totals count unfiltered zones. `tdns`
+warns when it sees that combination on an older server.
+
 #### Importing zones
 
 `tdns import` posts an RFC 1035 (BIND style) zone file to an existing Primary or

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -86,6 +86,25 @@ func buildZonesListQuery(filterName, filterType string, page, perPage int) url.V
 	return q
 }
 
+// minServerSideFilterVersion is the first release whose /api/zones/list
+// honors filterName and filterType.
+const minServerSideFilterVersion = "15.3"
+
+// warnIfPaginatedFilterUnsupported warns when a filter is combined with
+// pagination against a server that does not filter server-side. Such a server
+// paginates the unfiltered list, so filterZones only ever sees one page:
+// matches on the other pages are invisible, and the totals in the response
+// describe the unfiltered set. A server that will not report its version stays
+// silent rather than warning about not being able to warn.
+func warnIfPaginatedFilterUnsupported(client *api.Client) {
+	ok, version, err := client.ServerAtLeast(minServerSideFilterVersion)
+	if err != nil || ok {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "⚠️  This server (v%s) filters zones only from v%s onwards, so --name/--type are applied locally to the requested page.\n", version, minServerSideFilterVersion)
+	fmt.Fprintln(os.Stderr, "Matching zones on other pages are not shown, and the page totals count unfiltered zones. Drop --page/--per-page to filter across all zones.")
+}
+
 // filterZones applies filterName/filterType to zones client-side. Servers
 // v15.3+ already filter, making this a no-op; older servers ignore the
 // parameters and return everything, so this keeps the flags working there.
@@ -201,7 +220,11 @@ var listCmd = &cobra.Command{
 Zones can be filtered by name (--name, supporting * and ? wildcards) and by
 type (--type). Servers v15.3+ filter server-side; on older servers the same
 filter is applied client-side, so the flags work either way. Results can be
-paginated with --page and --per-page.`,
+paginated with --page and --per-page.
+
+Combining a filter with pagination needs a v15.3+ server to be accurate, since
+filtering an older server's results locally can only consider the page that was
+returned. The command warns when it detects that combination.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		filterType := ""
 		if listFilterType != "" {
@@ -213,8 +236,18 @@ paginated with --page and --per-page.`,
 			filterType = ct
 		}
 
+		client := api.New()
+
+		// Filtering a paginated list needs server-side filtering to be correct;
+		// only pay for the version lookup when both are actually in play.
+		filtering := listFilterName != "" || filterType != ""
+		paginating := listPage > 0 || listPerPage > 0
+		if filtering && paginating {
+			warnIfPaginatedFilterUnsupported(client)
+		}
+
 		q := buildZonesListQuery(listFilterName, filterType, listPage, listPerPage)
-		result, response, err := api.New().GetJSON("/api/zones/list", q)
+		result, response, err := client.GetJSON("/api/zones/list", q)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
 			os.Exit(1)
@@ -226,8 +259,7 @@ paginated with --page and --per-page.`,
 			return
 		}
 
-		showFooter := listPage > 0 || listPerPage > 0
-		fmt.Print(formatZonesList(response, listFilterName, filterType, showFooter))
+		fmt.Print(formatZonesList(response, listFilterName, filterType, paginating))
 	},
 }
 

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -163,15 +163,40 @@ func TestFormatZonesListFull(t *testing.T) {
 	}
 }
 
-// runListCmd executes `tdns list <args>` against a stub server and returns
-// the query values the server received.
+// listRequest records what the stub server received for one API call.
+type listRequest struct {
+	path  string
+	query map[string][]string
+}
+
+// runListCmd executes `tdns list <args>` against a stub server reporting a
+// v15.3+ version, and returns the query values of the zones/list call.
 func runListCmd(t *testing.T, args ...string) map[string][]string {
 	t.Helper()
+	for _, r := range runListCmdRequests(t, "15.3", args...) {
+		if r.path == "/api/zones/list" {
+			return r.query
+		}
+	}
+	t.Fatal("no request to /api/zones/list")
+	return nil
+}
 
-	var gotQuery map[string][]string
+// runListCmdRequests executes `tdns list <args>` against a stub server that
+// reports serverVersion, and returns every request it received in order. An
+// empty serverVersion omits the field, standing in for a server whose version
+// cannot be read.
+func runListCmdRequests(t *testing.T, serverVersion string, args ...string) []listRequest {
+	t.Helper()
+
+	var got []listRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotQuery = r.URL.Query()
+		got = append(got, listRequest{path: r.URL.Path, query: r.URL.Query()})
 		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/api/settings/get") {
+			fmt.Fprintf(w, `{"status":"ok","response":{"version":%q}}`, serverVersion)
+			return
+		}
 		fmt.Fprint(w, `{"status":"ok","response":{"zones":[]}}`)
 	}))
 	defer srv.Close()
@@ -201,7 +226,67 @@ func runListCmd(t *testing.T, args ...string) map[string][]string {
 	}
 	wp.Close()
 
-	return gotQuery
+	return got
+}
+
+// paths returns the request paths in the order they were received.
+func paths(reqs []listRequest) []string {
+	out := make([]string, 0, len(reqs))
+	for _, r := range reqs {
+		out = append(out, r.path)
+	}
+	return out
+}
+
+func TestListCmdChecksVersionOnlyWhenFilteringPaginatedResults(t *testing.T) {
+	// The version lookup is an extra round-trip, so it must not happen unless a
+	// filter and pagination are combined.
+	for _, tt := range []struct {
+		name string
+		args []string
+	}{
+		{"plain list", nil},
+		{"filter only", []string{"--name", "ex*"}},
+		{"type filter only", []string{"--type", "Primary"}},
+		{"pagination only", []string{"--page", "2"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := paths(runListCmdRequests(t, "15.3", tt.args...))
+			if len(got) != 1 || got[0] != "/api/zones/list" {
+				t.Errorf("requests = %v, want only /api/zones/list", got)
+			}
+		})
+	}
+
+	for _, args := range [][]string{
+		{"--name", "ex*", "--page", "2"},
+		{"--type", "Primary", "--per-page", "5"},
+	} {
+		got := paths(runListCmdRequests(t, "15.3", args...))
+		want := []string{"/api/settings/get", "/api/zones/list"}
+		if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+			t.Errorf("`list %v` requests = %v, want %v", args, got, want)
+		}
+	}
+}
+
+func TestListCmdWarnsWhenServerCannotFilterPaginatedResults(t *testing.T) {
+	// The listing itself must still be requested and rendered; the warning is
+	// advisory, not a refusal.
+	for _, version := range []string{"15.2", "14.0", ""} {
+		reqs := runListCmdRequests(t, version, "--name", "ex*", "--page", "2")
+		if got := paths(reqs); len(got) == 0 || got[len(got)-1] != "/api/zones/list" {
+			t.Errorf("server v%q: requests = %v, want the listing to still run", version, got)
+		}
+		for _, r := range reqs {
+			if r.path != "/api/zones/list" {
+				continue
+			}
+			if got := r.query["filterName"]; len(got) != 1 || got[0] != "ex*" {
+				t.Errorf("server v%q: filterName = %v, want it sent anyway", version, got)
+			}
+		}
+	}
 }
 
 func TestListCmdSendsNoParamsByDefault(t *testing.T) {


### PR DESCRIPTION
`/api/zones/list` only honors filterName and `filterType` from v15.3, which `filterZones` compensates for by filtering locally. That fallback is only correct for an unpaginated listing: an older server ignores the filter but still paginates, so it returns one page of the full zone list and the local filter can only match within that page. Zones matching on other pages are never shown, and the page totals in the response count unfiltered zones, so the footer disagrees with the rows above it.

Check the server version when a filter is combined with --page/--per-page and warn that results are limited to the returned page, suggesting the filter be used without pagination to search all zones. The listing still runs: the combination is imprecise rather than wrong to attempt, and reusing the existing --name fallback beats refusing outright. The version lookup is an extra round-trip, so it only happens for that flag combination, and a server that will not report its version stays silent instead of warning about being unable to warn.